### PR TITLE
Add method and subcommand to get unit microservices

### DIFF
--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -540,6 +540,18 @@ class AMClient(object):
             method=utils.METHOD_GET,
         )
 
+    def get_jobs(self):
+        """Get a list of jobs ran for a unit (transfer or ingest)."""
+        url = "{}/api/v2beta/jobs/{}".format(self.am_url, self.unit_uuid)
+        params = {}
+        for attribute in ["microservice", "link_uuid", "name"]:
+            value = getattr(self, "job_{}".format(attribute), None)
+            if value is not None:
+                params[attribute] = value
+        return utils._call_url_json(
+            url, headers=self._am_auth_headers(), params=params, method=utils.METHOD_GET
+        )
+
     def create_package(self):
         """Create a transfer using the new API v2 package endpoint."""
         url = "{}/api/v2beta/package/".format(self.am_url)

--- a/amclient/amclientargs.py
+++ b/amclient/amclientargs.py
@@ -19,6 +19,7 @@ AIP_UUID = Arg(name="aip_uuid", help="UUID of the target AIP", type=None)
 DIP_UUID = Arg(name="dip_uuid", help="UUID of the target DIP", type=None)
 SIP_UUID = Arg(name="sip_uuid", help="UUID of the target SIP", type=None)
 TRANSFER_UUID = Arg(name="transfer_uuid", help="UUID of the target Transfer", type=None)
+UNIT_UUID = Arg(name="unit_uuid", help="UUID of the target unit", type=None)
 AM_API_KEY = Arg(name="am_api_key", help="Archivematica API key", type=None)
 SS_API_KEY = Arg(name="ss_api_key", help="Storage Service API key", type=None)
 TRANSFER_SOURCE = Arg(name="transfer_source", help="Transfer source UUID", type=None)
@@ -131,6 +132,23 @@ TRANSFER_NAME = Opt(
     help="A name for the transfer",
     default="amclient-transfer",
     type=None,
+)
+JOB_MICROSERVICE = Opt(
+    name="job-microservice",
+    metavar="JOBMICROSERVICE",
+    help="Filter by microservice",
+    default=None,
+    type=None,
+)
+JOB_LINK_UUID = Opt(
+    name="job-link-uuid",
+    metavar="JOBLINKUUID",
+    help="Filter by job link UUID",
+    default=None,
+    type=None,
+)
+JOB_NAME = Opt(
+    name="job-name", metavar="JOBNAME", help="Filter by name", default=None, type=None
 )
 
 # Sub-command configuration: give them a name, help text, a tuple of ``Arg``
@@ -283,6 +301,19 @@ SUBCOMMANDS = (
         help="Extract a file from a package in the storage service.",
         args=(SS_API_KEY, PACKAGE_UUID, RELATIVE_PATH),
         opts=(SS_USER_NAME, SS_URL, DIRECTORY, SAVEAS_FILENAME),
+    ),
+    SubCommand(
+        name="get-jobs",
+        help="Retrieve a list of jobs ran for a unit (transfer or ingest).",
+        args=(AM_API_KEY, UNIT_UUID),
+        opts=(
+            AM_USER_NAME,
+            AM_URL,
+            JOB_MICROSERVICE,
+            JOB_LINK_UUID,
+            JOB_NAME,
+            OUTPUT_MODE,
+        ),
     ),
 )
 

--- a/fixtures/vcr_cassettes/jobs.yaml
+++ b/fixtures/vcr_cassettes/jobs.yaml
@@ -1,0 +1,608 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode 'ApiKey test:test'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: http://192.168.168.192/api/v2beta/jobs/ca480d94-892c-4d99-bbb1-290698406571
+  response:
+    body:
+      string: !!python/unicode '[{"status": "COMPLETE", "tasks": [{"uuid": "2bcb3e40-5b66-432c-a25d-93e869827a83",
+        "exit_code": 0}, {"uuid": "443b92a3-470b-4ec2-8c57-dea9006277ba", "exit_code":
+        0}, {"uuid": "5796dd25-1f43-4f4c-a3ea-166ff4bdd2ad", "exit_code": 0}, {"uuid":
+        "70e71773-bbd3-4c89-8ff6-265aa991b715", "exit_code": 0}, {"uuid": "9ef0ec8b-027c-4743-9054-51979770b7b0",
+        "exit_code": 0}, {"uuid": "bf5c2a95-511a-4a31-9718-03b06f1ed2d7", "exit_code":
+        0}, {"uuid": "cad99f5c-f9f9-4695-9479-71781a0a262c", "exit_code": 0}, {"uuid":
+        "d1397901-9b63-4430-94ee-4fb9a3637620", "exit_code": 0}, {"uuid": "e49584a3-6b38-4eec-b5f8-28d8a512f594",
+        "exit_code": 0}, {"uuid": "e9064fd3-93a1-4a4f-848b-37b120b1cebf", "exit_code":
+        0}, {"uuid": "f973f03f-9653-4165-8af5-b3f66def59f3", "exit_code": 0}], "microservice":
+        "Scan for viruses", "uuid": "01233bfd-5405-4232-a098-9e1234dd7702", "link_uuid":
+        "1c2550f1-3fc0-45d8-8bc4-4c06d720283b", "name": "Scan for viruses"}, {"status":
+        "COMPLETE", "tasks": [], "microservice": "Identify file format", "uuid": "02d07c50-e9cd-4378-8483-accfa405d0fe",
+        "link_uuid": "c3269a0a-91db-44e8-96d0-9c748cf80177", "name": "Determine which
+        files to identify"}, {"status": "COMPLETE", "tasks": [{"uuid": "62843ffb-1920-41a1-b20e-f2e0a1c155cb",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "0d0b3070-0b13-4d0e-9db0-2151c0181f22",
+        "link_uuid": "bda96b35-48c7-44fc-9c9e-d7c5a05016c1", "name": "Check if file
+        or folder"}, {"status": "COMPLETE", "tasks": [{"uuid": "531477db-3a44-452b-9123-c690453a1408",
+        "exit_code": 0}], "microservice": "Complete transfer", "uuid": "0f6af028-a678-4f2c-985c-ef52ed463c2f",
+        "link_uuid": "d27fd07e-d3ed-4767-96a5-44a2251c6d0a", "name": "Move to SIP
+        creation directory for completed transfers"}, {"status": "COMPLETE", "tasks":
+        [], "microservice": "Validation", "uuid": "11e5d093-1810-490e-8b18-68559f7a16d4",
+        "link_uuid": "70fc7040-d4fb-4d19-a0e6-792387ca1006", "name": "Perform policy
+        checks on originals?"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify
+        DSpace files", "uuid": "15a07937-14ac-48d7-8972-ab3701b1cccc", "link_uuid":
+        "d0dfbd93-d2d0-44db-9945-94fd8de8a1d4", "name": "Identify DSpace text files"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "a866425f-7deb-40e5-8324-b6b469beaac6",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "15aa4ca7-5d04-4c5b-8d78-b398d5cfc732",
+        "link_uuid": "26bf24c9-9139-4923-bf99-aa8648b1692b", "name": "Set transfer
+        type: DSpace"}, {"status": "COMPLETE", "tasks": [{"uuid": "3e722b0c-455a-41f4-8aca-de2e21894531",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "162484b8-65cc-4e0b-9b2d-e02e7a52e2c4",
+        "link_uuid": "87e7659c-d5de-4541-a09c-6deec966a0c0", "name": "Verify mets_structmap.xml
+        compliance"}, {"status": "COMPLETE", "tasks": [{"uuid": "9a0ff593-c803-40d6-b5b9-251340f6088b",
+        "exit_code": 0}], "microservice": "Generate METS.xml document", "uuid": "19dd3210-f1ca-45c3-baf9-a454a5a39653",
+        "link_uuid": "307edcde-ad10-401c-92c4-652917c993ed", "name": "Generate METS.xml
+        document"}, {"status": "COMPLETE", "tasks": [{"uuid": "abe7fee7-cd52-42ed-a2f7-f1518b14f87a",
+        "exit_code": 0}], "microservice": "Characterize and extract metadata", "uuid": "1c4e9667-b570-403c-ad4f-a5b6494fd826",
+        "link_uuid": "1b1a4565-b501-407b-b40f-2f20889423f1", "name": "Load labels
+        from metadata/file_labels.csv"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "fc5b29ae-9281-4c5d-a905-eec5ce991aa9", "exit_code": 0}], "microservice": "Generate
+        transfer structure report", "uuid": "1c6b9fe8-ee7a-4916-af5f-fc8d227712aa",
+        "link_uuid": "4efe00da-6ed0-45dd-89ca-421b78c4b6be", "name": "Save directory
+        tree"}, {"status": "COMPLETE", "tasks": [{"uuid": "90c04556-a4dd-41b2-ab16-4d8233f4df36",
+        "exit_code": 0}], "microservice": "Complete transfer", "uuid": "251ba103-fd8a-47c8-9a41-7c3da15dc92a",
+        "link_uuid": "675acd22-828d-4949-adc7-1888240f5e3d", "name": "Parse external
+        METS"}, {"status": "COMPLETE", "tasks": [{"uuid": "e0d5ef2b-52e7-46d4-a24d-f7ff54f544cd",
+        "exit_code": 0}], "microservice": "Quarantine", "uuid": "27568f5d-9e21-4e71-bfbe-8162a5fbfbbc",
+        "link_uuid": "39e58573-2dbc-4939-bce0-96b2f55dae28", "name": "Move to workFlowDecisions-quarantineSIP
+        directory"}, {"status": "COMPLETE", "tasks": [], "microservice": "Generate transfer
+        structure report", "uuid": "2987ed8b-dafc-4db9-9847-2c7e9e301528", "link_uuid":
+        "56eebd45-5600-4768-a8c2-ec0114555a3d", "name": "Generate transfer structure
+        report"}, {"status": "COMPLETE", "tasks": [{"uuid": "120f8c42-4dbe-4165-9181-b7fcd871c1b0",
+        "exit_code": 1}], "microservice": "Extract packages", "uuid": "30474e75-6c52-46e3-8934-1855e25dbc56",
+        "link_uuid": "b944ec7f-7f99-491f-986d-58914c9bb4fa", "name": "Determine if
+        transfer contains packages"}, {"status": "COMPLETE", "tasks": [{"uuid": "22366ae0-ca7c-4914-ae24-81a285e701ef",
+        "exit_code": 0}, {"uuid": "37df5d95-45c4-4e70-8e16-d03d9386fb3d", "exit_code":
+        0}, {"uuid": "67b4bf95-0974-4d3a-b74d-5baac6d3a826", "exit_code": 0}, {"uuid":
+        "7ea07f33-9964-4198-a8b5-719d5acee646", "exit_code": 0}, {"uuid": "893b04ab-ed6b-4f05-b59c-ec80b7337dff",
+        "exit_code": 0}, {"uuid": "ad494036-d372-4c6b-b411-87f6f521e4c4", "exit_code":
+        0}, {"uuid": "b794380d-e357-4ed5-ac0c-06f255ef4d34", "exit_code": 0}, {"uuid":
+        "d573fcc9-ae91-4070-9f63-1bdd12c888e4", "exit_code": 0}, {"uuid": "d63bba14-1f9f-40f8-921d-82feb07f4210",
+        "exit_code": 0}, {"uuid": "fbbd9a85-394a-43ec-9915-6b7bbed88ea0", "exit_code":
+        0}], "microservice": "Validation", "uuid": "37f35256-45ed-4120-a38d-b0a5a1dfbfe0",
+        "link_uuid": "a536828c-be65-4088-80bd-eb511a0a063d", "name": "Validate formats"},
+        {"status": "COMPLETE", "tasks": [], "microservice": "Quarantine", "uuid": "3bc1c1e1-86a0-4cad-9cd9-4b574080dffe",
+        "link_uuid": "a6e97805-a420-41af-b708-2a56de5b47a6", "name": "Designate to
+        process as a DSpace transfer"}, {"status": "COMPLETE", "tasks": [], "microservice":
+        "Include default Transfer processingMCP.xml", "uuid": "3d022b67-ba30-4c12-88f4-8f0887054683",
+        "link_uuid": "d6f6f5db-4cc2-4652-9283-9ec6a6d181e5", "name": "Assign UUIDs
+        to directories?"}, {"status": "COMPLETE", "tasks": [{"uuid": "70a3147e-ea33-4290-86f5-c2fc663b1487",
+        "exit_code": 0}], "microservice": "Include default Transfer processingMCP.xml", "uuid":
+        "438f13bc-8f1b-4c51-98c3-accc3e457db5", "link_uuid": "b08ad32b-f94f-4c2a-9fb0-9ef9328718dd",
+        "name": "Assign UUIDs to directories"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "9260102c-bf06-4577-b3f0-d656f2ae649e", "exit_code": 0}], "microservice": "Verify
+        transfer checksum", "uuid": "45227afe-9ad5-4d70-ab4e-fc24fbbdb3f2", "link_uuid":
+        "5e4bd4e8-d158-4c2a-be89-51e3e9bd4a06", "name": "Verify metadata directory
+        checksums"}, {"status": "COMPLETE", "tasks": [{"uuid": "7bc27af8-5806-4115-8f8f-49fc7ef92183",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "485a7c08-1fad-4e32-821b-669e80776dd2",
+        "link_uuid": "8f639582-8881-4a8b-8574-d2f86dc4db3d", "name": "Move to processing
+        directory"}, {"status": "COMPLETE", "tasks": [], "microservice": "Examine contents",
+        "uuid": "54205b52-2572-4a88-b276-2f25cd0c77ab", "link_uuid": "accea2bf-ba74-4a3a-bb97-614775c74459",
+        "name": "Examine contents?"}, {"status": "COMPLETE", "tasks": [{"uuid": "81d80780-d4bf-4f70-94c4-3de13c9d7d3e",
+        "exit_code": 0}], "microservice": "Clean up names", "uuid": "5d582d29-9741-47d7-ad76-2aec612c410f",
+        "link_uuid": "2584b25c-8d98-44b7-beca-2b3ea2ea2505", "name": "Sanitize object''s
+        file and directory names"}, {"status": "COMPLETE", "tasks": [], "microservice": "Quarantine",
+        "uuid": "6865acde-58af-4b6e-840e-53ea90c38889", "link_uuid": "55de1490-f3a0-4e1e-a25b-38b75f4f05e3",
+        "name": "Find type to process as"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "e523a958-388a-4743-b650-709b48b27052", "exit_code": 0}], "microservice": "Extract
+        packages", "uuid": "6a09e366-f8d1-4fdb-b6cd-2f4f3343dceb", "link_uuid": "cc16178b-b632-4624-9091-822dd802a2c6",
+        "name": "Move to extract packages"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "bdb3310b-0d79-4a7d-a7be-6b84841f6a95", "exit_code": 0}], "microservice": "Complete
+        transfer", "uuid": "6c5bf57d-028c-4107-b6c3-2da4117f8be3", "link_uuid": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d",
+        "name": "Create transfer metadata XML"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "ea3ff112-b067-42ff-bada-cdb17f6e1ad1", "exit_code": 0}], "microservice": "Generate
+        transfer structure report", "uuid": "7314ece7-ef5d-40fb-9225-13e4f34ae2db",
+        "link_uuid": "559d9b14-05bf-4136-918a-de74a821b759", "name": "Move to generate
+        transfer tree"}, {"status": "COMPLETE", "tasks": [{"uuid": "451f20e0-39c4-4f6a-9ff5-9d52b668caab",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "74266c67-bf4e-456f-abb8-f168b1c4f38c",
+        "link_uuid": "aa9ba088-0b1e-4962-a9d7-79d7a0cbea2d", "name": "Attempt restructure
+        for compliance"}, {"status": "COMPLETE", "tasks": [{"uuid": "6c45dd0c-dfb3-4c80-b99f-6bfc4921ab63",
+        "exit_code": 0}], "microservice": "Include default Transfer processingMCP.xml", "uuid":
+        "84a78da4-5488-4bb7-b5dd-e145cf2a71af", "link_uuid": "209400c1-5619-4acc-b091-b9d9c8fbb1c0",
+        "name": "Include default Transfer processingMCP.xml"}, {"status": "COMPLETE",
+        "tasks": [], "microservice": "Quarantine", "uuid": "87d5859f-6e58-403f-bde8-f622d0f88d61",
+        "link_uuid": "05f99ffd-abf2-4f5a-9ec8-f80a59967b89", "name": "Workflow decision
+        - send transfer to quarantine"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "2b7ed475-4b56-45ff-9579-8a11dd79ba09", "exit_code": 0}], "microservice": "Identify
+        file format", "uuid": "8d76118f-a78c-485d-8a1c-67ee283b6155", "link_uuid":
+        "d1b27e9e-73c8-4954-832c-36bd1e00c802", "name": "Move to select file ID tool"},
+        {"status": "COMPLETE", "tasks": [], "microservice": "Examine contents", "uuid": "8e4346b7-61a5-4348-a2b2-dafda5cb28a9",
+        "link_uuid": "192315ea-a1bf-44cf-8cb4-0b3edd1522a6", "name": "Check for specialized
+        processing"}, {"status": "COMPLETE", "tasks": [{"uuid": "560befa7-f850-48ff-9dfd-a59d90889de5",
+        "exit_code": 0}], "microservice": "Include default Transfer processingMCP.xml", "uuid":
+        "90d5f202-76ef-405e-829c-809a6c44112c", "link_uuid": "6bd4d385-c490-4c42-a195-dace8697891c",
+        "name": "Rename with transfer UUID"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "0e6c5024-3d40-40d5-97d1-07afa03c0dfc", "exit_code": 0}], "microservice": "Characterize
+        and extract metadata", "uuid": "97c9b723-40f2-4517-8bb0-984eb0aacaa5", "link_uuid":
+        "f8ef02c4-f585-4b0d-9b6f-3cef6fbe527f", "name": "Store file modification dates"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "e0e5e289-ac5e-4673-a502-b3bc1fbf1a8f",
+        "exit_code": 179}], "microservice": "Create SIP from Transfer", "uuid": "9a73a9b9-5371-4364-8daa-d7dffc6716a6",
+        "link_uuid": "032cdc54-0b9b-4caf-86e8-10d63efbaec0", "name": "Check transfer
+        directory for objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "1c44b4e7-5628-4d33-8138-d5cbcc411c6c",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "9c6f3a9a-c79d-4e88-8b7e-ade5a42be228",
+        "link_uuid": "032cdc54-0b9b-4caf-86e8-10d63efbaec0", "name": "Check transfer
+        directory for objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "06882a02-eec7-4de6-a6e8-4b7470917a12",
+        "exit_code": 0}, {"uuid": "28b9c6f7-8853-495b-8d2a-3dfa6757d081", "exit_code":
+        0}, {"uuid": "345cd41b-3fee-4d6d-b9cc-a8b66ef2a7ba", "exit_code": 0}, {"uuid":
+        "3b66c687-2e7d-4dda-9cd1-c69802add373", "exit_code": 0}, {"uuid": "5761aef4-8321-48e6-81de-9fe66eb470d1",
+        "exit_code": 0}, {"uuid": "7f93065c-a9d0-4fda-be5e-f79bc5c9c34c", "exit_code":
+        0}, {"uuid": "b71c42e1-ed04-453a-bcca-45fa2995e9f0", "exit_code": 0}, {"uuid":
+        "c1cecd7e-0ed7-46fe-8dd9-86c49bfde99a", "exit_code": 0}, {"uuid": "c49476cc-e677-4e6b-b73c-52721ab8123a",
+        "exit_code": 0}, {"uuid": "e29078dd-b375-44b9-af2b-3454d2428ec9", "exit_code":
+        0}], "microservice": "Assign file UUIDs and checksums", "uuid": "9fe8bcf7-583b-41ce-8c17-90fd3900fc43",
+        "link_uuid": "52269473-5325-4a11-b38a-c4aafcbd8f54", "name": "Assign file
+        UUIDs to objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "19b82242-9d12-470f-93ed-a5e3e16bd3ae",
+        "exit_code": 0}, {"uuid": "48feda81-27c6-4c70-854b-6199b7ef16d5", "exit_code":
+        0}, {"uuid": "79b1ae79-4606-4c71-8c99-9ca1f2cc96ba", "exit_code": 0}, {"uuid":
+        "8d32dd96-b8ae-45b6-ac96-caaa709d2c42", "exit_code": 0}, {"uuid": "8fc383a6-75b6-4066-ba28-86437994d600",
+        "exit_code": 0}, {"uuid": "a8c74805-8fd5-4e81-a0f9-f843389ff315", "exit_code":
+        0}, {"uuid": "b01521e9-8f91-490e-bd2c-2f9be5a4a699", "exit_code": 0}, {"uuid":
+        "b9d93893-9c43-4c2c-856d-4c9d8a75f993", "exit_code": 0}, {"uuid": "e7dffb14-5bb1-474f-b35b-1a57619c7a9d",
+        "exit_code": 0}, {"uuid": "f48fa269-04fd-44bb-bc08-d8164225c1fb", "exit_code":
+        0}], "microservice": "Characterize and extract metadata", "uuid": "a1914a8c-ecd0-4324-9323-69a8e3e1d069",
+        "link_uuid": "303a65f6-a16f-4a06-807b-cb3425a30201", "name": "Characterize
+        and extract metadata"}, {"status": "COMPLETE", "tasks": [{"uuid": "3cfa73eb-3894-4749-8143-c3f4b18b250f",
+        "exit_code": 0}], "microservice": "Generate transfer structure report", "uuid": "b56158d2-2667-4853-8c7b-ab8480d656c8",
+        "link_uuid": "6eca2676-b4ed-48d9-adb0-374e1d5c6e71", "name": "Move to processing
+        directory"}, {"status": "COMPLETE", "tasks": [{"uuid": "5d55e1bb-b9eb-46fd-b253-7c30779427e6",
+        "exit_code": 0}], "microservice": "Characterize and extract metadata", "uuid": "b5851196-17b5-4ffa-8693-2c6f9d3c3a01",
+        "link_uuid": "1a136608-ae7b-42b4-bf2f-de0e514cfd47", "name": "Load rights"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "0bbf7baf-1641-434d-a636-5cfd19162377",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "b917087f-0004-4ae6-bf76-a12b7b5d4117",
+        "link_uuid": "f378ec85-adcc-4ee6-ada2-bc90cfe20efb", "name": "Serialize Dublin
+        Core metadata to disk"}, {"status": "COMPLETE", "tasks": [{"uuid": "6927ea48-bbbe-4aa7-b2d3-f353fbfcf112",
+        "exit_code": 0}], "microservice": "Examine contents", "uuid": "b918e51a-c253-4048-9c0b-aa62de3f17b0",
+        "link_uuid": "dae3c416-a8c2-4515-9081-6dbd7b265388", "name": "Move to examine
+        contents"}, {"status": "COMPLETE", "tasks": [{"uuid": "0b3f7be3-ca2d-429f-b643-a2896d70bab1",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "b9de007f-77cd-414d-a0f9-3bb93eb074fe",
+        "link_uuid": "45063ad6-f374-4215-a2c4-ac47be4ce2cd", "name": "Verify transfer
+        compliance"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify DSpace
+        files", "uuid": "bb579f26-3189-461c-b7b8-c9bfabf42aba", "link_uuid": "8ec0b0c1-79ad-4d22-abcd-8e95fcceabbc",
+        "name": "Identify DSpace mets files"}, {"status": "COMPLETE", "tasks": [],
+        "microservice": "Create SIP from Transfer", "uuid": "c6f06144-ba65-4c6d-9b77-63373e196fa6",
+        "link_uuid": "bb194013-597c-4e4a-8493-b36d190f8717", "name": "Create SIP(s)"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "04bf53a1-9423-4ac3-92c5-10872abd2b79",
+        "exit_code": 0}, {"uuid": "0796bc00-285a-4793-a2e3-ffd7e467c37c", "exit_code":
+        0}, {"uuid": "25978bd0-3890-4d32-8a8d-f4c79b95b457", "exit_code": 0}, {"uuid":
+        "465b617f-37b4-486c-b3e3-1c9fc5660feb", "exit_code": 0}, {"uuid": "4bf6c81c-cbc9-4041-8816-64eb293aef7c",
+        "exit_code": 0}, {"uuid": "4ef325dc-0bfa-4807-858c-7e3991f8a0d2", "exit_code":
+        0}, {"uuid": "60d2fc46-5ebc-4c03-800b-abc76891cae3", "exit_code": 0}, {"uuid":
+        "77a0fd0d-61cb-4f2b-a6b6-824c24bdd50f", "exit_code": 0}, {"uuid": "7afc2346-7ed3-466c-bd49-86d70a4740ed",
+        "exit_code": 0}, {"uuid": "8ad19529-b01b-42cf-a28f-e1c17a25cec3", "exit_code":
+        0}], "microservice": "Assign file UUIDs and checksums", "uuid": "cc8ab98a-3420-441e-b623-af84f0d69b3a",
+        "link_uuid": "28a9f8a8-0006-4828-96d5-892e6e279f72", "name": "Assign checksums
+        and file sizes to objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "a6dfa4c2-c8b0-4281-a7d9-540c31b3e36c",
+        "exit_code": 0}], "microservice": "Clean up names", "uuid": "d4e51c50-bf55-406d-aab7-b9e1aada961d",
+        "link_uuid": "a329d39b-4711-4231-b54e-b5958934dccb", "name": "Sanitize Transfer
+        name"}, {"status": "COMPLETE", "tasks": [{"uuid": "05c171c7-6b43-4cbd-8242-ee62879a7fc0",
+        "exit_code": 0}, {"uuid": "4a355674-c86e-4bb2-88e4-9d918c0a0aea", "exit_code":
+        0}, {"uuid": "51b437ad-80c2-48d9-a6f3-813822bfda9d", "exit_code": 0}, {"uuid":
+        "57747f94-e35f-4578-a78c-057a7dae3360", "exit_code": 0}, {"uuid": "6eb67a5a-7c3c-4b3b-8c41-c27c9817adea",
+        "exit_code": 0}, {"uuid": "98f69e82-7bbd-463e-87e0-171f23332fd0", "exit_code":
+        0}, {"uuid": "9e40016a-4f63-48c9-96fe-2adacdd5665a", "exit_code": 0}, {"uuid":
+        "ba422384-096f-41a5-990e-1d614a37c609", "exit_code": 0}, {"uuid": "d016bbe2-9d8a-4841-9311-8801186cd8a4",
+        "exit_code": 0}, {"uuid": "d5a2883b-7b56-4ba2-98ee-9978f9e2587d", "exit_code":
+        0}], "microservice": "Identify file format", "uuid": "dbf1ffb3-2f9e-4764-9646-0147d8ba5ed4",
+        "link_uuid": "2522d680-c7d9-4d06-8b11-a28d8bd8a71f", "name": "Identify file
+        format"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify file format",
+        "uuid": "de4aaa9f-0ab1-44fc-be83-9d7fa4bf4b5d", "link_uuid": "f09847c2-ee51-429a-9478-a860477f6b8d",
+        "name": "Do you want to perform file format identification?"}, {"status":
+        "COMPLETE", "tasks": [{"uuid": "13000fc4-d421-4d63-ba2b-0fb7c217d166", "exit_code":
+        0}], "microservice": "Create SIP from Transfer", "uuid": "e2fec1aa-bd72-4577-96f4-64bff7a698b3",
+        "link_uuid": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5", "name": "Move to SIP
+        creation directory for completed transfers"}, {"status": "COMPLETE", "tasks":
+        [{"uuid": "7501302f-19d3-4142-9dc6-cee3e1fb76c5", "exit_code": 0}], "microservice":
+        "Scan for viruses", "uuid": "eb58e65e-47bb-4e00-831d-0707d5566969", "link_uuid":
+        "d7e6404a-a186-4806-a130-7e6d27179a15", "name": "Move to processing directory"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "36f3376c-07a8-4349-bbb5-e3e2f09ad1cf",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "eeebe9bf-6954-4d23-99e5-41e774b6fe1e",
+        "link_uuid": "39a128e3-c35d-40b7-9363-87f75091e1ff", "name": "Create SIP from
+        transfer objects"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify
+        DSpace files", "uuid": "f4b95ada-5551-4566-8d4a-5e513ef30b68", "link_uuid":
+        "2fd123ea-196f-4c9c-95c0-117aa65ed9c6", "name": "Verify checksums in fileSec
+        of DSpace METS files"}, {"status": "COMPLETE", "tasks": [], "microservice": "Create
+        SIP from Transfer", "uuid": "f58bb262-ad28-4155-a1c1-edb9de5083bd", "link_uuid":
+        "b04e9232-2aea-49fc-9560-27349c8eba4e", "name": "Load options to create SIPs"},
+        {"status": "COMPLETE", "tasks": [], "microservice": "Parse external files", "uuid":
+        "fb7d3456-8abb-431d-b0ff-2858f307e8a0", "link_uuid": "ec3c965c-c056-47e3-a551-ad1966e00824",
+        "name": "Determine if Dataverse METS XML needs to be parsed"}, {"status":
+        "COMPLETE", "tasks": [], "microservice": "Verify transfer compliance", "uuid": "ff04a265-e40f-469c-89af-d125727e24c8",
+        "link_uuid": "f2a019ea-0601-419c-a475-1b96a927a2fb", "name": "Set specialized
+        processing link"}]'
+    headers:
+      connection:
+      - keep-alive
+      content-language:
+      - en
+      content-type:
+      - application/json
+      date:
+      - Thu, 27 Jun 2019 23:04:27 GMT
+      server:
+      - nginx/1.14.2
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Language, Cookie
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode 'ApiKey test:test'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: http://192.168.168.192/api/v2beta/jobs/ca480d94-892c-4d99-bbb1-290698406571
+  response:
+    body:
+      string: !!python/unicode '[{"status": "COMPLETE", "tasks": [{"uuid": "2bcb3e40-5b66-432c-a25d-93e869827a83",
+        "exit_code": 0}, {"uuid": "443b92a3-470b-4ec2-8c57-dea9006277ba", "exit_code":
+        0}, {"uuid": "5796dd25-1f43-4f4c-a3ea-166ff4bdd2ad", "exit_code": 0}, {"uuid":
+        "70e71773-bbd3-4c89-8ff6-265aa991b715", "exit_code": 0}, {"uuid": "9ef0ec8b-027c-4743-9054-51979770b7b0",
+        "exit_code": 0}, {"uuid": "bf5c2a95-511a-4a31-9718-03b06f1ed2d7", "exit_code":
+        0}, {"uuid": "cad99f5c-f9f9-4695-9479-71781a0a262c", "exit_code": 0}, {"uuid":
+        "d1397901-9b63-4430-94ee-4fb9a3637620", "exit_code": 0}, {"uuid": "e49584a3-6b38-4eec-b5f8-28d8a512f594",
+        "exit_code": 0}, {"uuid": "e9064fd3-93a1-4a4f-848b-37b120b1cebf", "exit_code":
+        0}, {"uuid": "f973f03f-9653-4165-8af5-b3f66def59f3", "exit_code": 0}], "microservice":
+        "Scan for viruses", "uuid": "01233bfd-5405-4232-a098-9e1234dd7702", "link_uuid":
+        "1c2550f1-3fc0-45d8-8bc4-4c06d720283b", "name": "Scan for viruses"}, {"status":
+        "COMPLETE", "tasks": [], "microservice": "Identify file format", "uuid": "02d07c50-e9cd-4378-8483-accfa405d0fe",
+        "link_uuid": "c3269a0a-91db-44e8-96d0-9c748cf80177", "name": "Determine which
+        files to identify"}, {"status": "COMPLETE", "tasks": [{"uuid": "62843ffb-1920-41a1-b20e-f2e0a1c155cb",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "0d0b3070-0b13-4d0e-9db0-2151c0181f22",
+        "link_uuid": "bda96b35-48c7-44fc-9c9e-d7c5a05016c1", "name": "Check if file
+        or folder"}, {"status": "COMPLETE", "tasks": [{"uuid": "531477db-3a44-452b-9123-c690453a1408",
+        "exit_code": 0}], "microservice": "Complete transfer", "uuid": "0f6af028-a678-4f2c-985c-ef52ed463c2f",
+        "link_uuid": "d27fd07e-d3ed-4767-96a5-44a2251c6d0a", "name": "Move to SIP
+        creation directory for completed transfers"}, {"status": "COMPLETE", "tasks":
+        [], "microservice": "Validation", "uuid": "11e5d093-1810-490e-8b18-68559f7a16d4",
+        "link_uuid": "70fc7040-d4fb-4d19-a0e6-792387ca1006", "name": "Perform policy
+        checks on originals?"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify
+        DSpace files", "uuid": "15a07937-14ac-48d7-8972-ab3701b1cccc", "link_uuid":
+        "d0dfbd93-d2d0-44db-9945-94fd8de8a1d4", "name": "Identify DSpace text files"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "a866425f-7deb-40e5-8324-b6b469beaac6",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "15aa4ca7-5d04-4c5b-8d78-b398d5cfc732",
+        "link_uuid": "26bf24c9-9139-4923-bf99-aa8648b1692b", "name": "Set transfer
+        type: DSpace"}, {"status": "COMPLETE", "tasks": [{"uuid": "3e722b0c-455a-41f4-8aca-de2e21894531",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "162484b8-65cc-4e0b-9b2d-e02e7a52e2c4",
+        "link_uuid": "87e7659c-d5de-4541-a09c-6deec966a0c0", "name": "Verify mets_structmap.xml
+        compliance"}, {"status": "COMPLETE", "tasks": [{"uuid": "9a0ff593-c803-40d6-b5b9-251340f6088b",
+        "exit_code": 0}], "microservice": "Generate METS.xml document", "uuid": "19dd3210-f1ca-45c3-baf9-a454a5a39653",
+        "link_uuid": "307edcde-ad10-401c-92c4-652917c993ed", "name": "Generate METS.xml
+        document"}, {"status": "COMPLETE", "tasks": [{"uuid": "abe7fee7-cd52-42ed-a2f7-f1518b14f87a",
+        "exit_code": 0}], "microservice": "Characterize and extract metadata", "uuid": "1c4e9667-b570-403c-ad4f-a5b6494fd826",
+        "link_uuid": "1b1a4565-b501-407b-b40f-2f20889423f1", "name": "Load labels
+        from metadata/file_labels.csv"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "fc5b29ae-9281-4c5d-a905-eec5ce991aa9", "exit_code": 0}], "microservice": "Generate
+        transfer structure report", "uuid": "1c6b9fe8-ee7a-4916-af5f-fc8d227712aa",
+        "link_uuid": "4efe00da-6ed0-45dd-89ca-421b78c4b6be", "name": "Save directory
+        tree"}, {"status": "COMPLETE", "tasks": [{"uuid": "90c04556-a4dd-41b2-ab16-4d8233f4df36",
+        "exit_code": 0}], "microservice": "Complete transfer", "uuid": "251ba103-fd8a-47c8-9a41-7c3da15dc92a",
+        "link_uuid": "675acd22-828d-4949-adc7-1888240f5e3d", "name": "Parse external
+        METS"}, {"status": "COMPLETE", "tasks": [{"uuid": "e0d5ef2b-52e7-46d4-a24d-f7ff54f544cd",
+        "exit_code": 0}], "microservice": "Quarantine", "uuid": "27568f5d-9e21-4e71-bfbe-8162a5fbfbbc",
+        "link_uuid": "39e58573-2dbc-4939-bce0-96b2f55dae28", "name": "Move to workFlowDecisions-quarantineSIP
+        directory"}, {"status": "COMPLETE", "tasks": [], "microservice": "Generate transfer
+        structure report", "uuid": "2987ed8b-dafc-4db9-9847-2c7e9e301528", "link_uuid":
+        "56eebd45-5600-4768-a8c2-ec0114555a3d", "name": "Generate transfer structure
+        report"}, {"status": "COMPLETE", "tasks": [{"uuid": "120f8c42-4dbe-4165-9181-b7fcd871c1b0",
+        "exit_code": 1}], "microservice": "Extract packages", "uuid": "30474e75-6c52-46e3-8934-1855e25dbc56",
+        "link_uuid": "b944ec7f-7f99-491f-986d-58914c9bb4fa", "name": "Determine if
+        transfer contains packages"}, {"status": "COMPLETE", "tasks": [{"uuid": "22366ae0-ca7c-4914-ae24-81a285e701ef",
+        "exit_code": 0}, {"uuid": "37df5d95-45c4-4e70-8e16-d03d9386fb3d", "exit_code":
+        0}, {"uuid": "67b4bf95-0974-4d3a-b74d-5baac6d3a826", "exit_code": 0}, {"uuid":
+        "7ea07f33-9964-4198-a8b5-719d5acee646", "exit_code": 0}, {"uuid": "893b04ab-ed6b-4f05-b59c-ec80b7337dff",
+        "exit_code": 0}, {"uuid": "ad494036-d372-4c6b-b411-87f6f521e4c4", "exit_code":
+        0}, {"uuid": "b794380d-e357-4ed5-ac0c-06f255ef4d34", "exit_code": 0}, {"uuid":
+        "d573fcc9-ae91-4070-9f63-1bdd12c888e4", "exit_code": 0}, {"uuid": "d63bba14-1f9f-40f8-921d-82feb07f4210",
+        "exit_code": 0}, {"uuid": "fbbd9a85-394a-43ec-9915-6b7bbed88ea0", "exit_code":
+        0}], "microservice": "Validation", "uuid": "37f35256-45ed-4120-a38d-b0a5a1dfbfe0",
+        "link_uuid": "a536828c-be65-4088-80bd-eb511a0a063d", "name": "Validate formats"},
+        {"status": "COMPLETE", "tasks": [], "microservice": "Quarantine", "uuid": "3bc1c1e1-86a0-4cad-9cd9-4b574080dffe",
+        "link_uuid": "a6e97805-a420-41af-b708-2a56de5b47a6", "name": "Designate to
+        process as a DSpace transfer"}, {"status": "COMPLETE", "tasks": [], "microservice":
+        "Include default Transfer processingMCP.xml", "uuid": "3d022b67-ba30-4c12-88f4-8f0887054683",
+        "link_uuid": "d6f6f5db-4cc2-4652-9283-9ec6a6d181e5", "name": "Assign UUIDs
+        to directories?"}, {"status": "COMPLETE", "tasks": [{"uuid": "70a3147e-ea33-4290-86f5-c2fc663b1487",
+        "exit_code": 0}], "microservice": "Include default Transfer processingMCP.xml", "uuid":
+        "438f13bc-8f1b-4c51-98c3-accc3e457db5", "link_uuid": "b08ad32b-f94f-4c2a-9fb0-9ef9328718dd",
+        "name": "Assign UUIDs to directories"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "9260102c-bf06-4577-b3f0-d656f2ae649e", "exit_code": 0}], "microservice": "Verify
+        transfer checksum", "uuid": "45227afe-9ad5-4d70-ab4e-fc24fbbdb3f2", "link_uuid":
+        "5e4bd4e8-d158-4c2a-be89-51e3e9bd4a06", "name": "Verify metadata directory
+        checksums"}, {"status": "COMPLETE", "tasks": [{"uuid": "7bc27af8-5806-4115-8f8f-49fc7ef92183",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "485a7c08-1fad-4e32-821b-669e80776dd2",
+        "link_uuid": "8f639582-8881-4a8b-8574-d2f86dc4db3d", "name": "Move to processing
+        directory"}, {"status": "COMPLETE", "tasks": [], "microservice": "Examine contents",
+        "uuid": "54205b52-2572-4a88-b276-2f25cd0c77ab", "link_uuid": "accea2bf-ba74-4a3a-bb97-614775c74459",
+        "name": "Examine contents?"}, {"status": "COMPLETE", "tasks": [{"uuid": "81d80780-d4bf-4f70-94c4-3de13c9d7d3e",
+        "exit_code": 0}], "microservice": "Clean up names", "uuid": "5d582d29-9741-47d7-ad76-2aec612c410f",
+        "link_uuid": "2584b25c-8d98-44b7-beca-2b3ea2ea2505", "name": "Sanitize object''s
+        file and directory names"}, {"status": "COMPLETE", "tasks": [], "microservice": "Quarantine",
+        "uuid": "6865acde-58af-4b6e-840e-53ea90c38889", "link_uuid": "55de1490-f3a0-4e1e-a25b-38b75f4f05e3",
+        "name": "Find type to process as"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "e523a958-388a-4743-b650-709b48b27052", "exit_code": 0}], "microservice": "Extract
+        packages", "uuid": "6a09e366-f8d1-4fdb-b6cd-2f4f3343dceb", "link_uuid": "cc16178b-b632-4624-9091-822dd802a2c6",
+        "name": "Move to extract packages"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "bdb3310b-0d79-4a7d-a7be-6b84841f6a95", "exit_code": 0}], "microservice": "Complete
+        transfer", "uuid": "6c5bf57d-028c-4107-b6c3-2da4117f8be3", "link_uuid": "db99ab43-04d7-44ab-89ec-e09d7bbdc39d",
+        "name": "Create transfer metadata XML"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "ea3ff112-b067-42ff-bada-cdb17f6e1ad1", "exit_code": 0}], "microservice": "Generate
+        transfer structure report", "uuid": "7314ece7-ef5d-40fb-9225-13e4f34ae2db",
+        "link_uuid": "559d9b14-05bf-4136-918a-de74a821b759", "name": "Move to generate
+        transfer tree"}, {"status": "COMPLETE", "tasks": [{"uuid": "451f20e0-39c4-4f6a-9ff5-9d52b668caab",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "74266c67-bf4e-456f-abb8-f168b1c4f38c",
+        "link_uuid": "aa9ba088-0b1e-4962-a9d7-79d7a0cbea2d", "name": "Attempt restructure
+        for compliance"}, {"status": "COMPLETE", "tasks": [{"uuid": "6c45dd0c-dfb3-4c80-b99f-6bfc4921ab63",
+        "exit_code": 0}], "microservice": "Include default Transfer processingMCP.xml", "uuid":
+        "84a78da4-5488-4bb7-b5dd-e145cf2a71af", "link_uuid": "209400c1-5619-4acc-b091-b9d9c8fbb1c0",
+        "name": "Include default Transfer processingMCP.xml"}, {"status": "COMPLETE",
+        "tasks": [], "microservice": "Quarantine", "uuid": "87d5859f-6e58-403f-bde8-f622d0f88d61",
+        "link_uuid": "05f99ffd-abf2-4f5a-9ec8-f80a59967b89", "name": "Workflow decision
+        - send transfer to quarantine"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "2b7ed475-4b56-45ff-9579-8a11dd79ba09", "exit_code": 0}], "microservice": "Identify
+        file format", "uuid": "8d76118f-a78c-485d-8a1c-67ee283b6155", "link_uuid":
+        "d1b27e9e-73c8-4954-832c-36bd1e00c802", "name": "Move to select file ID tool"},
+        {"status": "COMPLETE", "tasks": [], "microservice": "Examine contents", "uuid": "8e4346b7-61a5-4348-a2b2-dafda5cb28a9",
+        "link_uuid": "192315ea-a1bf-44cf-8cb4-0b3edd1522a6", "name": "Check for specialized
+        processing"}, {"status": "COMPLETE", "tasks": [{"uuid": "560befa7-f850-48ff-9dfd-a59d90889de5",
+        "exit_code": 0}], "microservice": "Include default Transfer processingMCP.xml", "uuid":
+        "90d5f202-76ef-405e-829c-809a6c44112c", "link_uuid": "6bd4d385-c490-4c42-a195-dace8697891c",
+        "name": "Rename with transfer UUID"}, {"status": "COMPLETE", "tasks": [{"uuid":
+        "0e6c5024-3d40-40d5-97d1-07afa03c0dfc", "exit_code": 0}], "microservice": "Characterize
+        and extract metadata", "uuid": "97c9b723-40f2-4517-8bb0-984eb0aacaa5", "link_uuid":
+        "f8ef02c4-f585-4b0d-9b6f-3cef6fbe527f", "name": "Store file modification dates"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "e0e5e289-ac5e-4673-a502-b3bc1fbf1a8f",
+        "exit_code": 179}], "microservice": "Create SIP from Transfer", "uuid": "9a73a9b9-5371-4364-8daa-d7dffc6716a6",
+        "link_uuid": "032cdc54-0b9b-4caf-86e8-10d63efbaec0", "name": "Check transfer
+        directory for objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "1c44b4e7-5628-4d33-8138-d5cbcc411c6c",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "9c6f3a9a-c79d-4e88-8b7e-ade5a42be228",
+        "link_uuid": "032cdc54-0b9b-4caf-86e8-10d63efbaec0", "name": "Check transfer
+        directory for objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "06882a02-eec7-4de6-a6e8-4b7470917a12",
+        "exit_code": 0}, {"uuid": "28b9c6f7-8853-495b-8d2a-3dfa6757d081", "exit_code":
+        0}, {"uuid": "345cd41b-3fee-4d6d-b9cc-a8b66ef2a7ba", "exit_code": 0}, {"uuid":
+        "3b66c687-2e7d-4dda-9cd1-c69802add373", "exit_code": 0}, {"uuid": "5761aef4-8321-48e6-81de-9fe66eb470d1",
+        "exit_code": 0}, {"uuid": "7f93065c-a9d0-4fda-be5e-f79bc5c9c34c", "exit_code":
+        0}, {"uuid": "b71c42e1-ed04-453a-bcca-45fa2995e9f0", "exit_code": 0}, {"uuid":
+        "c1cecd7e-0ed7-46fe-8dd9-86c49bfde99a", "exit_code": 0}, {"uuid": "c49476cc-e677-4e6b-b73c-52721ab8123a",
+        "exit_code": 0}, {"uuid": "e29078dd-b375-44b9-af2b-3454d2428ec9", "exit_code":
+        0}], "microservice": "Assign file UUIDs and checksums", "uuid": "9fe8bcf7-583b-41ce-8c17-90fd3900fc43",
+        "link_uuid": "52269473-5325-4a11-b38a-c4aafcbd8f54", "name": "Assign file
+        UUIDs to objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "19b82242-9d12-470f-93ed-a5e3e16bd3ae",
+        "exit_code": 0}, {"uuid": "48feda81-27c6-4c70-854b-6199b7ef16d5", "exit_code":
+        0}, {"uuid": "79b1ae79-4606-4c71-8c99-9ca1f2cc96ba", "exit_code": 0}, {"uuid":
+        "8d32dd96-b8ae-45b6-ac96-caaa709d2c42", "exit_code": 0}, {"uuid": "8fc383a6-75b6-4066-ba28-86437994d600",
+        "exit_code": 0}, {"uuid": "a8c74805-8fd5-4e81-a0f9-f843389ff315", "exit_code":
+        0}, {"uuid": "b01521e9-8f91-490e-bd2c-2f9be5a4a699", "exit_code": 0}, {"uuid":
+        "b9d93893-9c43-4c2c-856d-4c9d8a75f993", "exit_code": 0}, {"uuid": "e7dffb14-5bb1-474f-b35b-1a57619c7a9d",
+        "exit_code": 0}, {"uuid": "f48fa269-04fd-44bb-bc08-d8164225c1fb", "exit_code":
+        0}], "microservice": "Characterize and extract metadata", "uuid": "a1914a8c-ecd0-4324-9323-69a8e3e1d069",
+        "link_uuid": "303a65f6-a16f-4a06-807b-cb3425a30201", "name": "Characterize
+        and extract metadata"}, {"status": "COMPLETE", "tasks": [{"uuid": "3cfa73eb-3894-4749-8143-c3f4b18b250f",
+        "exit_code": 0}], "microservice": "Generate transfer structure report", "uuid": "b56158d2-2667-4853-8c7b-ab8480d656c8",
+        "link_uuid": "6eca2676-b4ed-48d9-adb0-374e1d5c6e71", "name": "Move to processing
+        directory"}, {"status": "COMPLETE", "tasks": [{"uuid": "5d55e1bb-b9eb-46fd-b253-7c30779427e6",
+        "exit_code": 0}], "microservice": "Characterize and extract metadata", "uuid": "b5851196-17b5-4ffa-8693-2c6f9d3c3a01",
+        "link_uuid": "1a136608-ae7b-42b4-bf2f-de0e514cfd47", "name": "Load rights"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "0bbf7baf-1641-434d-a636-5cfd19162377",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "b917087f-0004-4ae6-bf76-a12b7b5d4117",
+        "link_uuid": "f378ec85-adcc-4ee6-ada2-bc90cfe20efb", "name": "Serialize Dublin
+        Core metadata to disk"}, {"status": "COMPLETE", "tasks": [{"uuid": "6927ea48-bbbe-4aa7-b2d3-f353fbfcf112",
+        "exit_code": 0}], "microservice": "Examine contents", "uuid": "b918e51a-c253-4048-9c0b-aa62de3f17b0",
+        "link_uuid": "dae3c416-a8c2-4515-9081-6dbd7b265388", "name": "Move to examine
+        contents"}, {"status": "COMPLETE", "tasks": [{"uuid": "0b3f7be3-ca2d-429f-b643-a2896d70bab1",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "b9de007f-77cd-414d-a0f9-3bb93eb074fe",
+        "link_uuid": "45063ad6-f374-4215-a2c4-ac47be4ce2cd", "name": "Verify transfer
+        compliance"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify DSpace
+        files", "uuid": "bb579f26-3189-461c-b7b8-c9bfabf42aba", "link_uuid": "8ec0b0c1-79ad-4d22-abcd-8e95fcceabbc",
+        "name": "Identify DSpace mets files"}, {"status": "COMPLETE", "tasks": [],
+        "microservice": "Create SIP from Transfer", "uuid": "c6f06144-ba65-4c6d-9b77-63373e196fa6",
+        "link_uuid": "bb194013-597c-4e4a-8493-b36d190f8717", "name": "Create SIP(s)"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "04bf53a1-9423-4ac3-92c5-10872abd2b79",
+        "exit_code": 0}, {"uuid": "0796bc00-285a-4793-a2e3-ffd7e467c37c", "exit_code":
+        0}, {"uuid": "25978bd0-3890-4d32-8a8d-f4c79b95b457", "exit_code": 0}, {"uuid":
+        "465b617f-37b4-486c-b3e3-1c9fc5660feb", "exit_code": 0}, {"uuid": "4bf6c81c-cbc9-4041-8816-64eb293aef7c",
+        "exit_code": 0}, {"uuid": "4ef325dc-0bfa-4807-858c-7e3991f8a0d2", "exit_code":
+        0}, {"uuid": "60d2fc46-5ebc-4c03-800b-abc76891cae3", "exit_code": 0}, {"uuid":
+        "77a0fd0d-61cb-4f2b-a6b6-824c24bdd50f", "exit_code": 0}, {"uuid": "7afc2346-7ed3-466c-bd49-86d70a4740ed",
+        "exit_code": 0}, {"uuid": "8ad19529-b01b-42cf-a28f-e1c17a25cec3", "exit_code":
+        0}], "microservice": "Assign file UUIDs and checksums", "uuid": "cc8ab98a-3420-441e-b623-af84f0d69b3a",
+        "link_uuid": "28a9f8a8-0006-4828-96d5-892e6e279f72", "name": "Assign checksums
+        and file sizes to objects"}, {"status": "COMPLETE", "tasks": [{"uuid": "a6dfa4c2-c8b0-4281-a7d9-540c31b3e36c",
+        "exit_code": 0}], "microservice": "Clean up names", "uuid": "d4e51c50-bf55-406d-aab7-b9e1aada961d",
+        "link_uuid": "a329d39b-4711-4231-b54e-b5958934dccb", "name": "Sanitize Transfer
+        name"}, {"status": "COMPLETE", "tasks": [{"uuid": "05c171c7-6b43-4cbd-8242-ee62879a7fc0",
+        "exit_code": 0}, {"uuid": "4a355674-c86e-4bb2-88e4-9d918c0a0aea", "exit_code":
+        0}, {"uuid": "51b437ad-80c2-48d9-a6f3-813822bfda9d", "exit_code": 0}, {"uuid":
+        "57747f94-e35f-4578-a78c-057a7dae3360", "exit_code": 0}, {"uuid": "6eb67a5a-7c3c-4b3b-8c41-c27c9817adea",
+        "exit_code": 0}, {"uuid": "98f69e82-7bbd-463e-87e0-171f23332fd0", "exit_code":
+        0}, {"uuid": "9e40016a-4f63-48c9-96fe-2adacdd5665a", "exit_code": 0}, {"uuid":
+        "ba422384-096f-41a5-990e-1d614a37c609", "exit_code": 0}, {"uuid": "d016bbe2-9d8a-4841-9311-8801186cd8a4",
+        "exit_code": 0}, {"uuid": "d5a2883b-7b56-4ba2-98ee-9978f9e2587d", "exit_code":
+        0}], "microservice": "Identify file format", "uuid": "dbf1ffb3-2f9e-4764-9646-0147d8ba5ed4",
+        "link_uuid": "2522d680-c7d9-4d06-8b11-a28d8bd8a71f", "name": "Identify file
+        format"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify file format",
+        "uuid": "de4aaa9f-0ab1-44fc-be83-9d7fa4bf4b5d", "link_uuid": "f09847c2-ee51-429a-9478-a860477f6b8d",
+        "name": "Do you want to perform file format identification?"}, {"status":
+        "COMPLETE", "tasks": [{"uuid": "13000fc4-d421-4d63-ba2b-0fb7c217d166", "exit_code":
+        0}], "microservice": "Create SIP from Transfer", "uuid": "e2fec1aa-bd72-4577-96f4-64bff7a698b3",
+        "link_uuid": "3e75f0fa-2a2b-4813-ba1a-b16b4be4cac5", "name": "Move to SIP
+        creation directory for completed transfers"}, {"status": "COMPLETE", "tasks":
+        [{"uuid": "7501302f-19d3-4142-9dc6-cee3e1fb76c5", "exit_code": 0}], "microservice":
+        "Scan for viruses", "uuid": "eb58e65e-47bb-4e00-831d-0707d5566969", "link_uuid":
+        "d7e6404a-a186-4806-a130-7e6d27179a15", "name": "Move to processing directory"},
+        {"status": "COMPLETE", "tasks": [{"uuid": "36f3376c-07a8-4349-bbb5-e3e2f09ad1cf",
+        "exit_code": 0}], "microservice": "Create SIP from Transfer", "uuid": "eeebe9bf-6954-4d23-99e5-41e774b6fe1e",
+        "link_uuid": "39a128e3-c35d-40b7-9363-87f75091e1ff", "name": "Create SIP from
+        transfer objects"}, {"status": "COMPLETE", "tasks": [], "microservice": "Identify
+        DSpace files", "uuid": "f4b95ada-5551-4566-8d4a-5e513ef30b68", "link_uuid":
+        "2fd123ea-196f-4c9c-95c0-117aa65ed9c6", "name": "Verify checksums in fileSec
+        of DSpace METS files"}, {"status": "COMPLETE", "tasks": [], "microservice": "Create
+        SIP from Transfer", "uuid": "f58bb262-ad28-4155-a1c1-edb9de5083bd", "link_uuid":
+        "b04e9232-2aea-49fc-9560-27349c8eba4e", "name": "Load options to create SIPs"},
+        {"status": "COMPLETE", "tasks": [], "microservice": "Parse external files", "uuid":
+        "fb7d3456-8abb-431d-b0ff-2858f307e8a0", "link_uuid": "ec3c965c-c056-47e3-a551-ad1966e00824",
+        "name": "Determine if Dataverse METS XML needs to be parsed"}, {"status":
+        "COMPLETE", "tasks": [], "microservice": "Verify transfer compliance", "uuid": "ff04a265-e40f-469c-89af-d125727e24c8",
+        "link_uuid": "f2a019ea-0601-419c-a475-1b96a927a2fb", "name": "Set specialized
+        processing link"}]'
+    headers:
+      connection:
+      - keep-alive
+      content-language:
+      - en
+      content-type:
+      - application/json
+      date:
+      - Thu, 27 Jun 2019 23:21:12 GMT
+      server:
+      - nginx/1.14.2
+      vary:
+      - Accept-Language, Cookie
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode 'ApiKey test:test'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: http://192.168.168.192/api/v2beta/jobs/ca480d94-892c-4d99-bbb1-290698406571?microservice=Clean+up+names
+  response:
+    body:
+      string: !!python/unicode '[{"status": "COMPLETE", "tasks": [{"uuid": "81d80780-d4bf-4f70-94c4-3de13c9d7d3e",
+        "exit_code": 0}], "microservice": "Clean up names", "uuid": "5d582d29-9741-47d7-ad76-2aec612c410f",
+        "link_uuid": "2584b25c-8d98-44b7-beca-2b3ea2ea2505", "name": "Sanitize object''s
+        file and directory names"}, {"status": "COMPLETE", "tasks": [{"uuid": "a6dfa4c2-c8b0-4281-a7d9-540c31b3e36c",
+        "exit_code": 0}], "microservice": "Clean up names", "uuid": "d4e51c50-bf55-406d-aab7-b9e1aada961d",
+        "link_uuid": "a329d39b-4711-4231-b54e-b5958934dccb", "name": "Sanitize Transfer
+        name"}]'
+    headers:
+      connection:
+      - keep-alive
+      content-language:
+      - en
+      content-type:
+      - application/json
+      date:
+      - Thu, 27 Jun 2019 23:21:12 GMT
+      server:
+      - nginx/1.14.2
+      vary:
+      - Accept-Language, Cookie
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode 'ApiKey test:test'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: http://192.168.168.192/api/v2beta/jobs/ca480d94-892c-4d99-bbb1-290698406571?link_uuid=87e7659c-d5de-4541-a09c-6deec966a0c0
+  response:
+    body:
+      string: !!python/unicode '[{"status": "COMPLETE", "tasks": [{"uuid": "3e722b0c-455a-41f4-8aca-de2e21894531",
+        "exit_code": 0}], "microservice": "Verify transfer compliance", "uuid": "162484b8-65cc-4e0b-9b2d-e02e7a52e2c4",
+        "link_uuid": "87e7659c-d5de-4541-a09c-6deec966a0c0", "name": "Verify mets_structmap.xml
+        compliance"}]'
+    headers:
+      connection:
+      - keep-alive
+      content-language:
+      - en
+      content-type:
+      - application/json
+      date:
+      - Thu, 27 Jun 2019 23:27:38 GMT
+      server:
+      - nginx/1.14.2
+      vary:
+      - Accept-Language, Cookie
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode 'ApiKey test:test'
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: http://192.168.168.192/api/v2beta/jobs/ca480d94-892c-4d99-bbb1-290698406571?name=Verify+metadata+directory+checksums
+  response:
+    body:
+      string: !!python/unicode '[{"status": "COMPLETE", "tasks": [{"uuid": "9260102c-bf06-4577-b3f0-d656f2ae649e",
+        "exit_code": 0}], "microservice": "Verify transfer checksum", "uuid": "45227afe-9ad5-4d70-ab4e-fc24fbbdb3f2",
+        "link_uuid": "5e4bd4e8-d158-4c2a-be89-51e3e9bd4a06", "name": "Verify metadata
+        directory checksums"}]'
+    headers:
+      connection:
+      - keep-alive
+      content-language:
+      - en
+      content-type:
+      - application/json
+      date:
+      - Thu, 27 Jun 2019 23:29:04 GMT
+      server:
+      - nginx/1.14.2
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Language, Cookie
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This PR adds a method and subcommand to get the microservices list of a transfer or ingest from [the `v2beta/microservices` endpoint](https://github.com/artefactual/archivematica/pull/1440).

Connected to https://github.com/archivematica/Issues/issues/722
Requires: https://github.com/artefactual/archivematica/pull/1440