### PR TITLE
Provide a mechanism to check distribution config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,24 @@
 
 .PHONY: clean package package-deps package-source package-upload package-wheel
 
-package-deps:		## Upgrade dependencies for packaging
+package-deps:                                   ## Upgrade dependencies for packaging
 	python3 -m pip install --upgrade twine wheel
 
-package-source:		## Package the source code
+package-source:                                 ## Package the source code
 	python3 setup.py sdist
 
-package-wheel: package-deps		## Package a Python wheel
+package-wheel: package-deps                     ## Package a Python wheel
 	python3 setup.py bdist_wheel --universal
 
-package-upload: package-deps package-source package-wheel	## Upload package
+package-check: package-source package-wheel     ## Check the distribution is valid
+	twine check dist/*
+
+package-upload: package-deps package-check      ## Upload package
 	twine upload dist/* --repository-url https://upload.pypi.org/legacy/
 
 package: package-upload
 
-clean:	## Clean the package directory
+clean:  ## Clean the package directory
 	rm -rf amclient.egg-info/
 	rm -rf build/
 	rm -rf dist/

--- a/amclient/version.py
+++ b/amclient/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.0.0rc3"
+__version__ = "1.0.0rc4"
 
 
 def version():

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     version=find_version("amclient/version.py"),
     description="Archivematica API client library.",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/artefactual-labs/amclient/",
     author="Artefactual",
     author_email="info@artefactual.com",


### PR DESCRIPTION
Provides a new `MakeFile` recipe to check the distribution and also configures `setup.py` to permit markdown for pypi. 

Running both the check command on its own, and in concert with upload, we get a positive output:
```
removing build/bdist.linux-x86_64/wheel
twine check dist/*
Checking distribution dist/amclient-1.0.0rc3-py2.py3-none-any.whl: Passed
Checking distribution dist/amclient-1.0.0rc3.tar.gz: Passed
twine upload dist/* --repository-url https://upload.pypi.org/legacy/
Enter your username: 
```

Connected to archivematica/issues#870