### PR TITLE
Create amclient command to create a location

### DIFF
--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -652,9 +652,13 @@ class AMClient(object):
             }
         url = "{0}/api/v2/location/".format(self.ss_url)
         desc = self.location_description if self.location_description else ""
+        pipelines = [
+            "/api/v2/pipeline/{}/".format(pipeline.strip())
+            for pipeline in self.pipeline_uuids.split(",")
+        ]
         params = {
             "description": desc,
-            "pipeline": ["/api/v2/pipeline/{}/".format(self.pipeline_uuid)],
+            "pipeline": pipelines,
             "space": "/api/v2/space/{}/".format(self.space_uuid),
             "default": self.default if self.default else False,
             "purpose": self.location_purpose,

--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -651,10 +651,9 @@ class AMClient(object):
                 "valid_purposes": self.list_location_purposes(),
             }
         url = "{0}/api/v2/location/".format(self.ss_url)
+        desc = self.location_description if self.location_description else ""
         params = {
-            "description": self.location_description
-            if self.location_description
-            else "",
+            "description": desc,
             "pipeline": ["/api/v2/pipeline/{}/".format(self.pipeline_uuid)],
             "space": "/api/v2/space/{}/".format(self.space_uuid),
             "default": self.default if self.default else False,

--- a/amclient/amclientargs.py
+++ b/amclient/amclientargs.py
@@ -12,8 +12,7 @@ try:
 except ImportError:
     from amclient import defaults, version
 
-
-# Reusable argument constants (for CLI).
+# Reusable argument constants (for CLI), E.g. arguments without reasonable defaults and are required to complete an API call.
 Arg = namedtuple("Arg", ["name", "help", "type"])
 AIP_UUID = Arg(name="aip_uuid", help="UUID of the target AIP", type=None)
 DIP_UUID = Arg(name="dip_uuid", help="UUID of the target DIP", type=None)
@@ -37,8 +36,16 @@ RELATIVE_PATH = Arg(
     help="Relative path to a file in an Archivematica package",
     type=None,
 )
-
-# Reusable option constants (for CLI).
+SPACE_UUID = Arg(
+    name="space_uuid", help="UUID of the space to add the location to", type=None
+)
+SPACE_RELATIVE_PATH = Arg(
+    name="space_relative_path", help="Path relative to a storage space", type=None
+)
+LOCATION_PURPOSE = Arg(
+    name="location_purpose", help="Purpose of storage space location", type=None
+)
+# Reusable option constants (for CLI), E.g. arguments with reasonable defaults or are not required to complete an API call.
 Opt = namedtuple("Opt", ["name", "metavar", "help", "default", "type"])
 AM_URL = Opt(
     name="am-url",
@@ -149,6 +156,20 @@ JOB_LINK_UUID = Opt(
 )
 JOB_NAME = Opt(
     name="job-name", metavar="JOBNAME", help="Filter by name", default=None, type=None
+)
+LOCATION_DESCRIPTION = Opt(
+    name="location-description",
+    metavar="LOCATIONDESCRIPTION",
+    help="Description for the storage location",
+    default=None,
+    type=None,
+)
+DEFAULT = Opt(
+    name="default",
+    metavar="DEFAULT",
+    help="Toggle setting to default",
+    default=False,
+    type=None,
 )
 
 # Sub-command configuration: give them a name, help text, a tuple of ``Arg``
@@ -314,6 +335,18 @@ SUBCOMMANDS = (
             JOB_NAME,
             OUTPUT_MODE,
         ),
+    ),
+    SubCommand(
+        name="create-location",
+        help="Create a new location in the Storage Service for a given space.",
+        args=(
+            PIPELINE_UUID,
+            SPACE_UUID,
+            LOCATION_PURPOSE,
+            SPACE_RELATIVE_PATH,
+            SS_API_KEY,
+        ),
+        opts=(SS_USER_NAME, SS_URL, LOCATION_DESCRIPTION, DEFAULT, OUTPUT_MODE),
     ),
 )
 

--- a/amclient/amclientargs.py
+++ b/amclient/amclientargs.py
@@ -26,6 +26,11 @@ PACKAGE_UUID = Arg(
     name="package_uuid", help="UUID of the package in the storage service", type=None
 )
 PIPELINE_UUID = Arg(name="pipeline_uuid", help="UUID of the pipeline to use", type=None)
+PIPELINE_UUIDS = Arg(
+    name="pipeline_uuids",
+    help="Single value or comma-separated list of pipelines to associate with a storage location",
+    type=None,
+)
 TRANSFER_DIRECTORY = Arg(
     name="transfer_directory",
     help="Directory of a potential Archivematica transfer",
@@ -342,7 +347,7 @@ SUBCOMMANDS = (
         name="create-location",
         help="Create a new location in the Storage Service for a given space.",
         args=(
-            PIPELINE_UUID,
+            PIPELINE_UUIDS,
             SPACE_UUID,
             LOCATION_PURPOSE,
             SPACE_RELATIVE_PATH,

--- a/amclient/amclientargs.py
+++ b/amclient/amclientargs.py
@@ -43,7 +43,9 @@ SPACE_RELATIVE_PATH = Arg(
     name="space_relative_path", help="Path relative to a storage space", type=None
 )
 LOCATION_PURPOSE = Arg(
-    name="location_purpose", help="Purpose of storage space location", type=None
+    name="location_purpose",
+    help='Purpose of storage space location valid choices: "AR", "AS", "CP", "DS", "SD", "SS", "BL", "TS", "RP"',
+    type=None,
 )
 # Reusable option constants (for CLI), E.g. arguments with reasonable defaults or are not required to complete an API call.
 Opt = namedtuple("Opt", ["name", "metavar", "help", "default", "type"])

--- a/fixtures/vcr_cassettes/create_location.yaml
+++ b/fixtures/vcr_cassettes/create_location.yaml
@@ -1,0 +1,147 @@
+interactions:
+- request:
+    body: '{"description": "AM Client unit test description", "pipeline": ["/api/v2/pipeline/d6aeb4e0-e836-4768-8225-26e5720950d3/",
+      "/api/v2/pipeline/26bda073-753b-42bd-b312-f39b7db4921d/"], "space": "/api/v2/space/30226523-c759-443f-95c9-0fa813034731/",
+      "default": false, "purpose": "TS", "relative_path": "this/is/a/path"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:5de62f6f4817f903dcfac47fa5cffd44685a2cf2
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '314'
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/location/
+  response:
+    body:
+      string: '{"default": false, "description": "AM Client unit test description",
+        "enabled": true, "path": "/this/is/a/path", "pipeline": ["/api/v2/pipeline/26bda073-753b-42bd-b312-f39b7db4921d/",
+        "/api/v2/pipeline/d6aeb4e0-e836-4768-8225-26e5720950d3/"], "purpose": "TS",
+        "quota": null, "relative_path": "this/is/a/path", "resource_uri": "/api/v2/location/e36a7649-74d7-4320-ba29-424ee3d6b837/",
+        "space": "/api/v2/space/30226523-c759-443f-95c9-0fa813034731/", "used": "0",
+        "uuid": "e36a7649-74d7-4320-ba29-424ee3d6b837"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Sep 2019 21:48:50 GMT
+      Location:
+      - http://192.168.168.192:8000/api/v2/location/e36a7649-74d7-4320-ba29-424ee3d6b837/
+      Server:
+      - nginx/1.16.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 201
+      message: CREATED
+- request:
+    body: '{"description": "AM Client unit test description", "pipeline": ["/api/v2/pipeline/d6aeb4e0-e836-4768-8225-26e5720950d3/"],
+      "space": "/api/v2/space/30226523-c759-443f-95c9-0fa813034731/", "default": true,
+      "purpose": "AS", "relative_path": "this/is/another/path"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:5de62f6f4817f903dcfac47fa5cffd44685a2cf2
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '261'
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/location/
+  response:
+    body:
+      string: '{"default": true, "description": "AM Client unit test description",
+        "enabled": true, "path": "/this/is/another/path", "pipeline": ["/api/v2/pipeline/d6aeb4e0-e836-4768-8225-26e5720950d3/"],
+        "purpose": "AS", "quota": null, "relative_path": "this/is/another/path", "resource_uri":
+        "/api/v2/location/e7648d04-2ff9-41bc-baab-060c6b7ec02c/", "space": "/api/v2/space/30226523-c759-443f-95c9-0fa813034731/",
+        "used": "0", "uuid": "e7648d04-2ff9-41bc-baab-060c6b7ec02c"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Sep 2019 21:48:50 GMT
+      Location:
+      - http://192.168.168.192:8000/api/v2/location/e7648d04-2ff9-41bc-baab-060c6b7ec02c/
+      Server:
+      - nginx/1.16.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 201
+      message: CREATED
+- request:
+    body: '{"description": "", "pipeline": ["/api/v2/pipeline/d6aeb4e0-e836-4768-8225-26e5720950d3/"],
+      "space": "/api/v2/space/30226523-c759-443f-95c9-0fa813034731/", "default": false,
+      "purpose": "DS", "relative_path": "this/is/a/path"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:5de62f6f4817f903dcfac47fa5cffd44685a2cf2
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '225'
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/location/
+  response:
+    body:
+      string: '{"default": false, "description": "", "enabled": true, "path": "/this/is/a/path",
+        "pipeline": ["/api/v2/pipeline/d6aeb4e0-e836-4768-8225-26e5720950d3/"], "purpose":
+        "DS", "quota": null, "relative_path": "this/is/a/path", "resource_uri": "/api/v2/location/7ba89b2f-9135-47dc-ba32-2799ee80cd9b/",
+        "space": "/api/v2/space/30226523-c759-443f-95c9-0fa813034731/", "used": "0",
+        "uuid": "7ba89b2f-9135-47dc-ba32-2799ee80cd9b"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Sep 2019 21:48:50 GMT
+      Location:
+      - http://192.168.168.192:8000/api/v2/location/7ba89b2f-9135-47dc-ba32-2799ee80cd9b/
+      Server:
+      - nginx/1.16.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 201
+      message: CREATED
+version: 1

--- a/fixtures/vcr_cassettes/create_location_failures.yaml
+++ b/fixtures/vcr_cassettes/create_location_failures.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: '{"description": "AM Client unit test description", "pipeline": ["/api/v2/pipeline/d6aeb4e0-e836-4768-8225-26e5720950d3/"],
+      "space": "/api/v2/space/badf00d3-c759-443f-95c9-0fa813034731/", "default": false,
+      "purpose": "AS", "relative_path": "this/is/a/path"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:5de62f6f4817f903dcfac47fa5cffd44685a2cf2
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '256'
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/location/
+  response:
+    body:
+      string: '{"error": "Could not find the provided space object via resource URI
+        ''/api/v2/space/badf00d3-c759-443f-95c9-0fa813034731/''."}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Sep 2019 21:48:50 GMT
+      Server:
+      - nginx/1.16.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 400
+      message: BAD REQUEST
+- request:
+    body: '{"description": "AM Client unit test description", "pipeline": ["/api/v2/pipeline/badf00d3-753b-42bd-b312-f39b7db4921d/"],
+      "space": "/api/v2/space/30226523-c759-443f-95c9-0fa813034731/", "default": false,
+      "purpose": "DS", "relative_path": "this/is/a/path"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - ApiKey test:5de62f6f4817f903dcfac47fa5cffd44685a2cf2
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '256'
+      User-Agent:
+      - python-requests/2.22.0
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/location/
+  response:
+    body:
+      string: '{"error": "Could not find the provided pipeline object via resource
+        URI ''/api/v2/pipeline/badf00d3-753b-42bd-b312-f39b7db4921d/''."}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 23 Sep 2019 21:48:50 GMT
+      Server:
+      - nginx/1.16.0
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 400
+      message: BAD REQUEST
+version: 1


### PR DESCRIPTION
This commit sees the addition of a command to create a storage
location in the Archivematica Storage Service.

Connected to archivematica/issues#905

**NB.** I had a snipped included for testing, but must have forgotten to include it. For readers of this ticket, an example command might be: 

```
python3 -m amclient.amclient create-location \
 26bda073-753b-42bd-b312-f39b7db4921d,d6aeb4e0-e836-4768-8225-26e5720950d3 \
 30226523-c759-443f-95c9-0fa813034731 \
 "TS" \
 "multiple-pipeline-test" \
 test  \
 --ss-user-name test  \
 --ss-url http://127.0.0.1:62081  \
 --location-description "test"  \
 --default false
```

Example help following changes:
```
usage: amclient.py create-location [-h] [--ss-user-name USERNAME]
                                   [--ss-url URL]
                                   [--location-description LOCATIONDESCRIPTION]
                                   [--default DEFAULT] [--output-mode MODE]
                                   pipeline_uuids space_uuid location_purpose
                                   space_relative_path ss_api_key

positional arguments:
  pipeline_uuids        Single value or comma-separated list of pipelines to
                        associate with a storage location
  space_uuid            UUID of the space to add the location to
  location_purpose      Purpose of storage space location valid choices: "AR",
                        "AS", "CP", "DS", "SD", "SS", "BL", "TS", "RP"
  space_relative_path   Path relative to a storage space
  ss_api_key            Storage Service API key

optional arguments:
  -h, --help            show this help message and exit
  --ss-user-name USERNAME
                        Storage Service username. Default: test
  --ss-url URL          Storage Service URL. Default: http://127.0.0.1:62081
  --location-description LOCATIONDESCRIPTION
                        Description for the storage location
  --default DEFAULT     Toggle setting to default
  --output-mode MODE    How to print output, JSON (default) or Python
```