### PR TITLE
Release AMClient 1.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing
+
+Thank you for considering a contribution to the AMClient! Archivematica's API
+client library.
+
+This document outlines the change submission process for AMClient, along with
+our standards for new code contributions. Following these guidelines helps us
+to assess your changes faster and makes it easier for us to merge your
+submission!
+
+There are many ways to contribute:
+
+* submitting bug reports,
+* or writing code which can be incorporated into AMClient itself.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Submitting bugs](#submitting-bugs)
+- [Contribution standards](#contribution-standards)
+- [Contributor's Agreement](#contributors-agreement)
+  - [Why do I have to sign a Contributor's Agreement?](#why-do-i-have-to-sign-a-contributors-agreement)
+  - [How do I send in an agreement?](#how-do-i-send-in-an-agreement)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Submitting bugs
+
+If you find a security vulnerability, do NOT open an issue. Email
+security@artefactual.com instead.
+
+Issues should be filed in our collective
+[Archivematica related issues repository][am-issues]
+
+For user support, clarification, or issues related to your deployment and use
+of AMClient you can post in our [Archivematica forum][am-forum]. A post to the
+mailing list is always welcome!
+
+Useful questions to answer if you're having problems include:
+
+* What version of AMClient are you using?
+* How was it installed?
+* How was AMClient being used when this issue occurred?
+* What was the expected outcome?
+* What was the actual outcome?
+* Can we reproduce this reliably?
+
+## Contribution standards
+
+For more information on contribution guidelines and standards, see the
+CONTRIBUTING.md in the [Archivematica project][contribute-to-am].
+
+## Contributor's Agreement
+
+In order for the Archivematica development team to accept any patches or code
+commits, contributors must first sign this
+[Contributor's Agreement][contributors-agreement].
+
+The Archivematica contributor's agreement is based almost verbatim on the
+[Apache Foundation][apache-org]'s individual
+[contributor license][contributor-license].
+
+If you have any questions or concerns about the Contributor's Agreement, please
+email us at agreement@artefactual.com to discuss them.
+
+### Why do I have to sign a Contributor's Agreement?
+
+One of the key challenges for open source software is to support a
+collaborative development environment while protecting the rights of
+contributors and users over the long-term. Unifying Archivematica copyrights
+through contributor agreements is the best way to protect the availability and
+sustainability of Archivematica over the long-term as free and open-source
+software. In all cases, contributors who sign the Contributor's Agreement
+retain full rights to use their original contributions for any other purpose
+outside of Archivematica, while enabling Artefactual Systems, or any successor
+organization which may eventually take over responsibility for Archivematica,
+and the wider Archivematica community, to benefit from their collaboration and
+contributions in this open source project.
+
+[Artefactual Systems][af-systems] has made the decision and has a proven track
+record of making our intellectual property available to the community at large.
+By standardizing contributions on these agreements the Archivematica
+intellectual property position does not become too complicated. This ensures
+our resources are devoted to making our project the best they can be, rather
+than fighting legal battles over contributions.
+
+### How do I send in an agreement?
+
+Please print out, read, sign, and scan the
+[contributor agreement][contributors-agreement] and email it to
+agreement@artefactual.com. Alternatively, you may send an original signed
+agreement to:
+
+    Artefactual Systems Inc.
+    201 - 301 Sixth Street
+    New Westminster BC  V3L 3A7
+    Canada
+
+[am-issues]: https://github.com/archivematica/issues
+[am-forum]: https://groups.google.com/forum/#!forum/archivematica
+[contribute-to-am]: https://github.com/artefactual/archivematica
+[contributors-agreement]: https://wiki.archivematica.org/images/2/25/Contributor_agreement.txt
+[apache-org]: http://apache.org
+[contributor-license]: http://www.apache.org/licenses/icla.txt
+[af-systems]: http://artefactual.com

--- a/README.md
+++ b/README.md
@@ -2,8 +2,16 @@
 
 # amclient
 
-The transfers/amclient.py script is a module and CLI that provides
-functionality for interacting with the various Archivematica APIs.
+AMClient is an Archivematica API client library and Python package for making
+it easier to talk to Archivematica from your Python scripts. AMClient also acts
+as a command line application which can easily be combined with shell-scripts
+to perform the same functions as a Python script might.
+
+AMClient brings together the majority of the functionality of the two primary
+Archivematica components:
+
+* [Archivematica API][archivematica-api]
+* [Storage Service API][storage-service-api]
 
 Basic usage:
     `amclient.py <subcommand> [optional arguments] <positional argument(s)>`
@@ -44,3 +52,12 @@ Calling the module from Python:
     >>> am.list_storage_locations()
     ...json is output here...
 ```
+
+## CONTRIBUTING
+
+For information about contributing to this project please see the AMClient
+[CONTRIBUTING.md][contributing]
+
+[archivematica-api]: https://wiki.archivematica.org/Archivematica_API
+[storage-service-api]: https://wiki.archivematica.org/Storage_Service_API
+[contributing]: CONTRIBUTING.md

--- a/amclient/version.py
+++ b/amclient/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.0.0rc4"
+__version__ = "1.0.0"
 
 
 def version():

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
-requests<3.0
-six==1.12.0
-urllib3==1.25.3
+requests<3
+six<2
+urllib3<2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,6 @@
 -r base.txt
 pytest
-vcrpy>=1.0.0
-flake8==3.4.1
-flake8-import-order==0.13
+vcrpy<2; python_version <= '2.7'
+vcrpy>4; python_version >= '3.5'
+flake8>3
+flake8-import-order<1

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     ],
     keywords="Archivematica API Archivematica-Storage-Service SDK",
     packages=find_packages(exclude=["fixtures", "requirements", "tests*"]),
-    install_requires=["requests<3.0", "six", "urllib3"],
+    install_requires=["requests<3", "six<2", "urllib3<2"],
     include_package_data=True,
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
     # Entry point for the amclient binary


### PR DESCRIPTION
Updates AMClient to 1.1.0. This PR ties up a few loose ends including finalizing other PRs used in packages such as automation tools. We also pin and update the requirements where it is sensible. In the case of the requests library users may have seen a conflict e.g. [botocore example](https://github.com/aws/aws-cli/issues/4093) where it had itself pinned `urllib3` to something other than we wanted, usually for security purposes. 

Documentation has been updated and the links to markdown are below: 

* [README.md](https://github.com/artefactual-labs/amclient/blob/b38118d7a2ff8d1f21ae310c41377ac3091784ee/README.md)
* [CONTRIBUTING.md](https://github.com/artefactual-labs/amclient/blob/b38118d7a2ff8d1f21ae310c41377ac3091784ee/CONTRIBUTING.md)

I have been through the package with a nearly-fine toothed comb to see what else is needed and feel confident we're close to being able to release. Other suggestions about what we need to do to round off the edges before pushing a final `1.0.0` are most welcome. As much as anything I've tried to match the style of [mets-reader-writer](https://github.com/artefactual-labs/mets-reader-writer).

I have taken the liberty of updating the version number. Once this PR is reviewed and accepted we'll squish the other commits and then create a tag and push to PyPi. 

Connected to archivematica/issues#543