### PR TITLE
Enable streaming for API calls to extract files

### DIFF
--- a/amclient/amclientargs.py
+++ b/amclient/amclientargs.py
@@ -331,6 +331,12 @@ SUBCOMMANDS = (
         opts=(SS_USER_NAME, SS_URL, DIRECTORY, SAVEAS_FILENAME),
     ),
     SubCommand(
+        name="extract-file-stream",
+        help="Extract a file from a package in the storage service as a stream.",
+        args=(SS_API_KEY, PACKAGE_UUID, RELATIVE_PATH),
+        opts=(SS_USER_NAME, SS_URL),
+    ),
+    SubCommand(
         name="get-jobs",
         help="Retrieve a list of jobs ran for a unit (transfer or ingest).",
         args=(AM_API_KEY, UNIT_UUID),

--- a/amclient/version.py
+++ b/amclient/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 def version():


### PR DESCRIPTION
Example on the command-line:
```
python amclient.py extract-file-stream \
   --ss-user-name test \
   --ss-url http://127.0.0.1:62081 test c2d04940-0e23-49f0-b364-85e7b6ad91fa demo_csv-c2d04940-0e23-49f0-b364-85e7b6ad91fa/data/METS.c2d04940-0e23-49f0-b364-85e7b6ad91fa.xml
```
Users might want other objects from the archival package, they can try with:
```
python amclient.py extract-file-stream \
   --ss-user-name test \
   --ss-url http://127.0.0.1:62081 test c2d04940-0e23-49f0-b364-85e7b6ad91fa demo_csv-c2d04940-0e23-49f0-b364-85e7b6ad91fa/data/objects/bird.mp3 > my_music.mp3
```
And a good idea is to perform a checksum comparison on that. The MD5 checksum for `bird.mp3` in the `DemoTransferCSV` file is: `7f42199657dea535b6ad1963a6c7a2ac` 

Connected to archivematica/issues#644 