### PR TITLE
Add validate_csv method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 18.9b0
+  rev: 21.10b0
   hooks:
   - id: black
     args: [--safe, --quiet]
     language_version: python3
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.7
+  rev: 4.0.1
   hooks:
   - id: flake8
     language_version: python3

--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -214,7 +214,7 @@ class AMClient(object):
         return self._close_completed_units("ingest")
 
     def _close_completed_units(self, unit_type):
-        """Close all completed transfers/ingests.  """
+        """Close all completed transfers/ingests."""
         try:
             _completed_units = getattr(self, "completed_{0}s".format(unit_type))().get(
                 "results"
@@ -647,7 +647,7 @@ class AMClient(object):
         the caller is an API user. If the caller is the AMClient command-line
         then the stream contents are output to the console.
         """
-        self.output_mode = "".format(None)
+        self.output_mode = ""  # TODO: don't overwrite mode
         url = "{0}/api/v2/file/{1}/extract_file/?relative_path_to_file={2}".format(
             self.ss_url, self.package_uuid, self.relative_path
         )

--- a/amclient/version.py
+++ b/amclient/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 
 def version():

--- a/fixtures/validate_me.csv
+++ b/fixtures/validate_me.csv
@@ -1,0 +1,2 @@
+file,basis,status,determination_date,jurisdiction,start_date,end_date,terms,citation,note,grant_act,grant_restriction,grant_start_date,grant_end_date,grant_note,doc_id_type,doc_id_value,doc_id_role
+objects/image1.tif,copyright,copyrighted,2011-01-01,ca,2011-01-01,2013-12-31,,ha,Note about copyright.,disseminate,disallow,2011-01-01,2013-12-31,Grant note,Copyright documentation identifier type.,Copyright documentation identifier value.,Copyright documentation identifier role.

--- a/tests/test_amclient.py
+++ b/tests/test_amclient.py
@@ -295,8 +295,7 @@ class TestAMClient(unittest.TestCase):
 
     @vcr.use_cassette("fixtures/vcr_cassettes/dips_no_dips.yaml")
     def test_dips_no_dips(self):
-        """Test that we get no DIPs from the Storage Service if there are none.
-        """
+        """Test that we get no DIPs from the Storage Service if there are none."""
         dips = amclient.AMClient(
             ss_url=SS_URL, ss_user_name=SS_USER_NAME, ss_api_key=SS_API_KEY
         ).dips()
@@ -1172,8 +1171,7 @@ class TestAMClient(unittest.TestCase):
 
     @vcr.use_cassette("fixtures/vcr_cassettes/create_location_failures.yaml")
     def test_create_location_failure_responses(self):
-        """Test various calls that we don't expect to succeed using AMClient.
-        """
+        """Test various calls that we don't expect to succeed using AMClient."""
 
         purpose_aip_storage = "AS"
         purpose_dip_storage = "DS"
@@ -1274,7 +1272,7 @@ class TestAMClient(unittest.TestCase):
         http_error = requests.exceptions.HTTPError()
         error_message = {"valid": False, "reason": "A required field is missing."}
         http_error.response = mock.Mock()
-        http_error.response.json = error_message
+        http_error.response.json.return_value = error_message
         mock_request.side_effect = http_error
         client.enhanced_errors = True
         for validator in ["avalon", "rights"]:


### PR DESCRIPTION
Adds a `validate_csv` method to amclient which uses the `validate` endpoint available in AM 1.10+.

Two things that would be good to get some feedback on:
- There is no exception handling for FileNotFound errors, so if someone tries to validate a file that doesn't exist, that exception will be raised. I think that's the preferable approach but let me know if not?
- The `validate` endpoint returns a 400 if validation fails, along with a JSON response which indicates what caused validation to fail. Because of the exception handling in `_call_url_json` the actual reason for the validation isn't returned. Is this acceptable, or are there suggestions for returning a more helpful response?