### PR TITLE
Add delete_aip method to amclient

### DIFF
--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -121,6 +121,11 @@ class AMClient(object):
         param: stream
         param: cli_call
         param: enhanced_errors
+        param: event_reason
+        param: pipeline_uuid
+        param: pipeline_uuids
+        param: ss_user_id
+        param: ss_user_email
         """
         for key, val in kwargs.items():
             setattr(self, key, val)
@@ -570,6 +575,33 @@ class AMClient(object):
 
     def download_aip(self):
         return self.download_package(self.aip_uuid)
+
+    def delete_package(
+        self, package_uuid, pipeline_uuid, event_reason, ss_user_id, ss_user_email
+    ):
+        """Create a deletion request for a package."""
+        params = {
+            "pipeline": pipeline_uuid,
+            "event_reason": event_reason,
+            "user_id": ss_user_id,
+            "user_email": ss_user_email,
+        }
+        url = "{}/api/v2/file/{}/delete_aip/".format(self.ss_url, package_uuid)
+        return utils._call_url_json(
+            url,
+            headers=self._ss_auth_headers(),
+            params=json.dumps(params),
+            method=utils.METHOD_POST,
+        )
+
+    def delete_aip(self):
+        return self.delete_package(
+            self.aip_uuid,
+            self.pipeline_uuid,
+            self.event_reason,
+            self.ss_user_id,
+            self.ss_user_email,
+        )
 
     def list_storage_locations(self):
         """List all Storage Service locations."""

--- a/amclient/amclientargs.py
+++ b/amclient/amclientargs.py
@@ -52,6 +52,19 @@ LOCATION_PURPOSE = Arg(
     help='Purpose of storage space location valid choices: "AR", "AS", "CP", "DS", "SD", "SS", "BL", "TS", "RP"',
     type=None,
 )
+EVENT_REASON = Arg(
+    name="event_reason", help="Event reason for package deletion request", type=None
+)
+SS_USER_ID = Arg(
+    name="ss_user_id",
+    help="ID of Storage Service user making package deletion request, e.g. 1",
+    type=None,
+)
+SS_USER_EMAIL = Arg(
+    name="ss_user_email",
+    help="Email address of Storage Service user making package deletion request",
+    type=None,
+)
 # Reusable option constants (for CLI), E.g. arguments with reasonable defaults or are not required to complete an API call.
 Opt = namedtuple("Opt", ["name", "metavar", "help", "default", "type"])
 AM_URL = Opt(
@@ -261,6 +274,19 @@ SUBCOMMANDS = (
         help="Download the AIP with AIP_UUID.",
         args=(AIP_UUID, SS_API_KEY),
         opts=(SS_USER_NAME, SS_URL, DIRECTORY, OUTPUT_MODE),
+    ),
+    SubCommand(
+        name="delete-aip",
+        help="Create deletion request for the AIP with AIP_UUID.",
+        args=(
+            AIP_UUID,
+            SS_API_KEY,
+            PIPELINE_UUID,
+            EVENT_REASON,
+            SS_USER_ID,
+            SS_USER_EMAIL,
+        ),
+        opts=(SS_USER_NAME, SS_URL, OUTPUT_MODE),
     ),
     SubCommand(
         name="get-pipelines",

--- a/amclient/version.py
+++ b/amclient/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 
 def version():

--- a/fixtures/vcr_cassettes/delete_aip_fail.yaml
+++ b/fixtures/vcr_cassettes/delete_aip_fail.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: !!python/unicode '{"pipeline": "a49dce91-3dca-4228-a271-0327ea89afb6", "event_reason":
+      "Testing when deletion request doesn''t work", "user_id": "1", "user_email":
+      "test@example.com"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '164'
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/file/bad-aip-uuid/delete_aip/
+  response:
+    body:
+      string: !!python/unicode Resource with UUID bad-aip-uuid does not exist
+    headers:
+      connection:
+      - keep-alive
+      content-language:
+      - en
+      content-length:
+      - '46'
+      content-type:
+      - text/html; charset=utf-8
+      date:
+      - Tue, 30 Nov 2021 21:36:14 GMT
+      server:
+      - nginx/1.20.1
+      vary:
+      - Accept, Accept-Language, Cookie
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/fixtures/vcr_cassettes/delete_aip_success.yaml
+++ b/fixtures/vcr_cassettes/delete_aip_success.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: !!python/unicode '{"pipeline": "a49dce91-3dca-4228-a271-0327ea89afb6", "event_reason":
+      "Testing that deletion request works", "user_id": "1", "user_email": "test@example.com"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - !!python/unicode ApiKey test:test
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '157'
+      User-Agent:
+      - python-requests/2.26.0
+    method: POST
+    uri: http://192.168.168.192:8000/api/v2/file/fccc77cf-2045-44ed-9ddc-b335c63d5f9a/delete_aip/
+  response:
+    body:
+      string: !!python/unicode '{"message": "Delete request created successfully.",
+        "id": 2}'
+    headers:
+      connection:
+      - keep-alive
+      content-language:
+      - en
+      content-length:
+      - '60'
+      content-type:
+      - application/json
+      date:
+      - Tue, 30 Nov 2021 21:36:14 GMT
+      server:
+      - nginx/1.20.1
+      vary:
+      - Accept, Accept-Language, Cookie
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 202
+      message: Accepted
+version: 1

--- a/tests/test_amclient.py
+++ b/tests/test_amclient.py
@@ -422,6 +422,40 @@ class TestAMClient(unittest.TestCase):
         ).download_aip()
         assert aip_path is None
 
+    @vcr.use_cassette("fixtures/vcr_cassettes/delete_aip_success.yaml")
+    def test_delete_aip_success(self):
+        """Test that we can request deletion of existing AIP."""
+        aip_uuid = "fccc77cf-2045-44ed-9ddc-b335c63d5f9a"
+        pipeline_uuid = "a49dce91-3dca-4228-a271-0327ea89afb6"
+        response = amclient.AMClient(
+            aip_uuid=aip_uuid,
+            ss_url=SS_URL,
+            ss_user_name=SS_USER_NAME,
+            ss_api_key=SS_API_KEY,
+            pipeline_uuid=pipeline_uuid,
+            event_reason="Testing that deletion request works",
+            ss_user_id="1",
+            ss_user_email="test@example.com",
+        ).delete_aip()
+        assert response["message"] == "Delete request created successfully."
+
+    @vcr.use_cassette("fixtures/vcr_cassettes/delete_aip_fail.yaml")
+    def test_delete_aip_fail(self):
+        """Test that we can try to delete an AIP that does not exist."""
+        aip_uuid = "bad-aip-uuid"
+        pipeline_uuid = "a49dce91-3dca-4228-a271-0327ea89afb6"
+        response = amclient.AMClient(
+            aip_uuid=aip_uuid,
+            ss_url=SS_URL,
+            ss_user_name=SS_USER_NAME,
+            ss_api_key=SS_API_KEY,
+            pipeline_uuid=pipeline_uuid,
+            event_reason="Testing when deletion request doesn't work",
+            ss_user_id="1",
+            ss_user_email="test@example.com",
+        ).delete_aip()
+        assert response == errors.ERR_INVALID_RESPONSE
+
     @vcr.use_cassette("fixtures/vcr_cassettes/completed_ingests_ingests.yaml")
     def test_completed_ingests_ingests(self):
         """Test getting completed ingests when there are completed ingests


### PR DESCRIPTION
This PR adds a `delete_aip` method to amclient to cover the functionality of the corresponding Storage Service API endpoint.

Relates to https://github.com/archivematica/Issues/issues/1152