### PR TITLE
Add extract_aip_mets_file method

### DIFF
--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -747,6 +747,24 @@ class AMClient(object):
                         file_.write(chunk)
             return response.headers
 
+    def extract_aip_mets_file(self):
+        """Extract the METS file for an AIP with provided UUID.
+
+        If stream is True then the raw response is provided to the caller, if
+        the caller is an API user. If the caller is the AMClient command-line
+        then the stream contents are output to the console.
+        """
+        self.package_uuid = self.aip_uuid
+        package_details = self.get_package(params={"uuid": self.aip_uuid})
+        try:
+            current_path = package_details["objects"][0]["current_path"]
+        except KeyError:
+            return errors.ERR_PARSE_JSON
+        self.relative_path = utils.relative_path_to_aip_mets_file(
+            self.aip_uuid, current_path
+        )
+        return self.extract_file()
+
     def list_location_purposes(self):
         """List valid location purposes in the Storage Service."""
         return {

--- a/amclient/version.py
+++ b/amclient/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 
 def version():

--- a/fixtures/vcr_cassettes/test_extract_aip_mets_file.yaml
+++ b/fixtures/vcr_cassettes/test_extract_aip_mets_file.yaml
@@ -1,0 +1,890 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/file/?username=test&api_key=5de62f6f4817f903dcfac47fa5cffd44685a2cf2&uuid=64f4cb73-60bc-49f2-ab75-d83c9365b7d3
+  response:
+    body:
+      string: '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null,
+        "total_count": 1}, "objects": [{"current_full_path": "/var/archivematica/sharedDirectory/www/secondAIPsStore/64f4/cb73/60bc/49f2/ab75/d83c/9365/b7d3/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3.7z",
+        "current_location": "/api/v2/location/52dee701-e8fb-4aa9-92b3-b86ab8c24478/",
+        "current_path": "64f4/cb73/60bc/49f2/ab75/d83c/9365/b7d3/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3.7z",
+        "encrypted": false, "misc_attributes": {}, "origin_pipeline": "/api/v2/pipeline/6ba850ec-ec7f-4a53-9a8a-f3598aa39b93/",
+        "package_type": "AIP", "related_packages": [], "replicas": [], "replicated_package":
+        null, "resource_uri": "/api/v2/file/64f4cb73-60bc-49f2-ab75-d83c9365b7d3/",
+        "size": 1065067, "status": "UPLOADED", "uuid": "64f4cb73-60bc-49f2-ab75-d83c9365b7d3"}]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en
+      Content-Length:
+      - '847'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 01 Jun 2022 19:47:25 GMT
+      Server:
+      - nginx/1.20.2
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.1
+    method: GET
+    uri: http://192.168.168.192:8000/api/v2/file/64f4cb73-60bc-49f2-ab75-d83c9365b7d3/extract_file/?relative_path_to_file=mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/data/METS.64f4cb73-60bc-49f2-ab75-d83c9365b7d3.xml&username=test&api_key=5de62f6f4817f903dcfac47fa5cffd44685a2cf2
+  response:
+    body:
+      string: "<?xml version='1.0' encoding='UTF-8'?>\n<mets:mets xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"
+        xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:mets=\"http://www.loc.gov/METS/\"
+        xsi:schemaLocation=\"http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version1121/mets.xsd\">\n
+        \ <mets:metsHdr CREATEDATE=\"2022-06-01T13:39:33\"/>\n  <mets:dmdSec ID=\"dmdSec_1\"
+        CREATED=\"2022-06-01T13:39:33\" STATUS=\"original\">\n    <mets:mdWrap MDTYPE=\"PREMIS:OBJECT\">\n
+        \     <mets:xmlData>\n        <premis:object xmlns:premis=\"http://www.loc.gov/premis/v3\"
+        xsi:type=\"premis:intellectualEntity\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n          <premis:objectIdentifier>\n
+        \           <premis:objectIdentifierType>UUID</premis:objectIdentifierType>\n
+        \           <premis:objectIdentifierValue>64f4cb73-60bc-49f2-ab75-d83c9365b7d3</premis:objectIdentifierValue>\n
+        \         </premis:objectIdentifier>\n          <premis:originalName>mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3</premis:originalName>\n
+        \       </premis:object>\n      </mets:xmlData>\n    </mets:mdWrap>\n  </mets:dmdSec>\n
+        \ <mets:amdSec ID=\"amdSec_1\">\n    <mets:techMD ID=\"techMD_1\">\n      <mets:mdWrap
+        MDTYPE=\"PREMIS:OBJECT\">\n        <mets:xmlData>\n          <premis:object
+        xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:type=\"premis:file\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:objectIdentifier>\n
+        \             <premis:objectIdentifierType>UUID</premis:objectIdentifierType>\n
+        \             <premis:objectIdentifierValue>e7ecde2a-c936-4c80-acaf-73ee63d4a18b</premis:objectIdentifierValue>\n
+        \           </premis:objectIdentifier>\n            <premis:objectCharacteristics>\n
+        \             <premis:compositionLevel>0</premis:compositionLevel>\n              <premis:fixity>\n
+        \               <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>\n
+        \               <premis:messageDigest>6c6135a4dfdd19c5d9c55918b9501440bc0e250350c7de1a6e803b13469dbd64</premis:messageDigest>\n
+        \             </premis:fixity>\n              <premis:size>1052413</premis:size>\n
+        \             <premis:format>\n                <premis:formatDesignation>\n
+        \                 <premis:formatName>Matroska</premis:formatName>\n                  <premis:formatVersion></premis:formatVersion>\n
+        \               </premis:formatDesignation>\n                <premis:formatRegistry>\n
+        \                 <premis:formatRegistryName>PRONOM</premis:formatRegistryName>\n
+        \                 <premis:formatRegistryKey>fmt/569</premis:formatRegistryKey>\n
+        \               </premis:formatRegistry>\n              </premis:format>\n
+        \             <premis:creatingApplication>\n                <premis:dateCreatedByApplication>2021-05-18T15:17:13Z</premis:dateCreatedByApplication>\n
+        \             </premis:creatingApplication>\n              <premis:objectCharacteristicsExtension>\n
+        \               <ffprobe>\n                  <program_version version=\"3.4.8-0ubuntu0.2\"
+        copyright=\"Copyright (c) 2007-2020 the FFmpeg developers\" compiler_ident=\"gcc
+        7 (Ubuntu 7.5.0-3ubuntu1~18.04)\" configuration=\"--prefix=/usr --extra-version=0ubuntu0.2
+        --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu
+        --enable-gpl --disable-stripping --enable-avresample --enable-avisynth --enable-gnutls
+        --enable-ladspa --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca
+        --enable-libcdio --enable-libflite --enable-libfontconfig --enable-libfreetype
+        --enable-libfribidi --enable-libgme --enable-libgsm --enable-libmp3lame --enable-libmysofa
+        --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse
+        --enable-librubberband --enable-librsvg --enable-libshine --enable-libsnappy
+        --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame
+        --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265
+        --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-omx
+        --enable-openal --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm
+        --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libopencv
+        --enable-libx264 --enable-shared\"/>\n                  <library_versions>\n
+        \                   <library_version name=\"libavutil\" major=\"55\" minor=\"78\"
+        micro=\"100\" version=\"3624548\" ident=\"Lavu55.78.100\"/>\n                    <library_version
+        name=\"libavcodec\" major=\"57\" minor=\"107\" micro=\"100\" version=\"3763044\"
+        ident=\"Lavc57.107.100\"/>\n                    <library_version name=\"libavformat\"
+        major=\"57\" minor=\"83\" micro=\"100\" version=\"3756900\" ident=\"Lavf57.83.100\"/>\n
+        \                   <library_version name=\"libavdevice\" major=\"57\" minor=\"10\"
+        micro=\"100\" version=\"3738212\" ident=\"Lavd57.10.100\"/>\n                    <library_version
+        name=\"libavfilter\" major=\"6\" minor=\"107\" micro=\"100\" version=\"420708\"
+        ident=\"Lavfi6.107.100\"/>\n                    <library_version name=\"libswscale\"
+        major=\"4\" minor=\"8\" micro=\"100\" version=\"264292\" ident=\"SwS4.8.100\"/>\n
+        \                   <library_version name=\"libswresample\" major=\"2\" minor=\"9\"
+        micro=\"100\" version=\"133476\" ident=\"SwR2.9.100\"/>\n                    <library_version
+        name=\"libpostproc\" major=\"54\" minor=\"7\" micro=\"100\" version=\"3540836\"
+        ident=\"postproc54.7.100\"/>\n                  </library_versions>\n                  <streams>\n
+        \                   <stream index=\"0\" codec_name=\"mpeg4\" codec_long_name=\"MPEG-4
+        part 2\" profile=\"Simple Profile\" codec_type=\"video\" codec_time_base=\"1/25\"
+        codec_tag_string=\"[0][0][0][0]\" codec_tag=\"0x0000\" width=\"1280\" height=\"720\"
+        coded_width=\"1280\" coded_height=\"720\" has_b_frames=\"0\" sample_aspect_ratio=\"1:1\"
+        display_aspect_ratio=\"16:9\" pix_fmt=\"yuv420p\" level=\"1\" chroma_location=\"left\"
+        refs=\"1\" quarter_sample=\"false\" divx_packed=\"false\" r_frame_rate=\"25/1\"
+        avg_frame_rate=\"25/1\" time_base=\"1/1000\" duration_ts=\"3600\" duration=\"3.600000\"
+        extradata=\" 00000000: 0000 01b0 0100 0001 b589 1300 0001 0000  ................
+        00000010: 0001 2000 c48d 8800 cd28 045a 1443 0000  .. ......(.Z.C.. 00000020:
+        01b2 4c61 7663 3534 2e39 322e 3130 30    ..Lavc54.92.100 \">\n                      <disposition
+        default=\"1\" dub=\"0\" original=\"0\" comment=\"0\" lyrics=\"0\" karaoke=\"0\"
+        forced=\"0\" hearing_impaired=\"0\" visual_impaired=\"0\" clean_effects=\"0\"
+        attached_pic=\"0\" timed_thumbnails=\"0\"/>\n                    </stream>\n
+        \                   <stream index=\"1\" codec_name=\"aac\" codec_long_name=\"AAC
+        (Advanced Audio Coding)\" profile=\"LC\" codec_type=\"audio\" codec_time_base=\"1/48000\"
+        codec_tag_string=\"[0][0][0][0]\" codec_tag=\"0x0000\" sample_fmt=\"fltp\"
+        sample_rate=\"48000\" channels=\"6\" channel_layout=\"5.1\" bits_per_sample=\"0\"
+        r_frame_rate=\"0/0\" avg_frame_rate=\"0/0\" time_base=\"1/1000\" duration_ts=\"3600\"
+        duration=\"3.600000\" extradata=\" 00000000: 11b0                                     ..
+        \">\n                      <disposition default=\"1\" dub=\"0\" original=\"0\"
+        comment=\"0\" lyrics=\"0\" karaoke=\"0\" forced=\"0\" hearing_impaired=\"0\"
+        visual_impaired=\"0\" clean_effects=\"0\" attached_pic=\"0\" timed_thumbnails=\"0\"/>\n
+        \                   </stream>\n                  </streams>\n                  <chapters>\n
+        \   </chapters>\n                  <format filename=\"/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/objects/SampleVideo_1280x720_1mb.mkv\"
+        nb_streams=\"2\" nb_programs=\"0\" format_name=\"matroska,webm\" format_long_name=\"Matroska
+        / WebM\" duration=\"3.600000\" size=\"1052413\" bit_rate=\"2338695\" probe_score=\"100\">\n
+        \                   <tag key=\"ENCODER\" value=\"Lavf53.24.2\"/>\n                  </format>\n
+        \               </ffprobe>\n                <MediaInfo xmlns=\"https://mediaarea.net/mediainfo\"
+        xsi:schemaLocation=\"https://mediaarea.net/mediainfo https://mediaarea.net/mediainfo/mediainfo_2_0.xsd\"
+        version=\"2.0\">\n                  <creatingLibrary version=\"18.05\" url=\"https://mediaarea.net/MediaInfo\">MediaInfoLib</creatingLibrary>\n
+        \                 <media ref=\"/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/objects/SampleVideo_1280x720_1mb.mkv\">\n
+        \                   <track type=\"General\">\n                      <UniqueID>103050277581039363832065562162189258835</UniqueID>\n
+        \                     <VideoCount>1</VideoCount>\n                      <AudioCount>1</AudioCount>\n
+        \                     <FileExtension>mkv</FileExtension>\n                      <Format>Matroska</Format>\n
+        \                     <Format_Version>2</Format_Version>\n                      <FileSize>1052413</FileSize>\n
+        \                     <Duration>3.600</Duration>\n                      <OverallBitRate>2338696</OverallBitRate>\n
+        \                     <IsStreamable>Yes</IsStreamable>\n                      <File_Modified_Date>UTC
+        2021-05-18 15:17:13</File_Modified_Date>\n                      <File_Modified_Date_Local>2021-05-18
+        15:17:13</File_Modified_Date_Local>\n                      <Encoded_Application>Lavf53.24.2</Encoded_Application>\n
+        \                     <Encoded_Library>Lavf53.24.2</Encoded_Library>\n                    </track>\n
+        \                   <track type=\"Video\">\n                      <StreamOrder>0</StreamOrder>\n
+        \                     <ID>1</ID>\n                      <UniqueID>1</UniqueID>\n
+        \                     <Format>MPEG-4 Visual</Format>\n                      <Format_Profile>Simple</Format_Profile>\n
+        \                     <Format_Level>1</Format_Level>\n                      <Format_Settings_BVOP>No</Format_Settings_BVOP>\n
+        \                     <Format_Settings_QPel>No</Format_Settings_QPel>\n                      <Format_Settings_GMC>0</Format_Settings_GMC>\n
+        \                     <Format_Settings_Matrix>Default (H.263)</Format_Settings_Matrix>\n
+        \                     <CodecID>V_MPEG4/ISO/ASP</CodecID>\n                      <Width>1280</Width>\n
+        \                     <Height>720</Height>\n                      <Sampled_Width>1280</Sampled_Width>\n
+        \                     <Sampled_Height>720</Sampled_Height>\n                      <PixelAspectRatio>1.000</PixelAspectRatio>\n
+        \                     <DisplayAspectRatio>1.778</DisplayAspectRatio>\n                      <FrameRate_Mode>VFR</FrameRate_Mode>\n
+        \                     <ColorSpace>YUV</ColorSpace>\n                      <ChromaSubsampling>4:2:0</ChromaSubsampling>\n
+        \                     <BitDepth>8</BitDepth>\n                      <ScanType>Progressive</ScanType>\n
+        \                     <Compression_Mode>Lossy</Compression_Mode>\n                      <Delay>0.000</Delay>\n
+        \                     <Encoded_Library>Lavc54.92.100</Encoded_Library>\n                      <Default>Yes</Default>\n
+        \                     <Forced>No</Forced>\n                    </track>\n
+        \                   <track type=\"Audio\">\n                      <StreamOrder>1</StreamOrder>\n
+        \                     <ID>2</ID>\n                      <UniqueID>2</UniqueID>\n
+        \                     <Format>AAC</Format>\n                      <Format_Profile>LC</Format_Profile>\n
+        \                     <CodecID>A_AAC-2</CodecID>\n                      <Duration>3.600</Duration>\n
+        \                     <Channels>6</Channels>\n                      <ChannelPositions>Front:
+        L C R, Side: L R, LFE</ChannelPositions>\n                      <ChannelLayout>C
+        L R Ls Rs LFE</ChannelLayout>\n                      <SamplesPerFrame>1024</SamplesPerFrame>\n
+        \                     <SamplingRate>48000</SamplingRate>\n                      <SamplingCount>172800</SamplingCount>\n
+        \                     <FrameRate>46.875</FrameRate>\n                      <Compression_Mode>Lossy</Compression_Mode>\n
+        \                     <Delay>0.005</Delay>\n                      <Delay_Source>Container</Delay_Source>\n
+        \                     <Default>Yes</Default>\n                      <Forced>No</Forced>\n
+        \                   </track>\n                  </media>\n                </MediaInfo>\n
+        \             </premis:objectCharacteristicsExtension>\n            </premis:objectCharacteristics>\n
+        \           <premis:originalName>%transferDirectory%objects/SampleVideo_1280x720_1mb.mkv</premis:originalName>\n
+        \         </premis:object>\n        </mets:xmlData>\n      </mets:mdWrap>\n
+        \   </mets:techMD>\n    <mets:digiprovMD ID=\"digiprovMD_1\">\n      <mets:mdWrap
+        MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n          <premis:event
+        xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>97cfeea0-4f4e-4b7e-a073-2f5238985e6f</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>ingestion</premis:eventType>\n
+        \           <premis:eventDateTime>2022-06-01T13:39:13.323265+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail></premis:eventDetail>\n
+        \           </premis:eventDetailInformation>\n            <premis:eventOutcomeInformation>\n
+        \             <premis:eventOutcome></premis:eventOutcome>\n              <premis:eventOutcomeDetail>\n
+        \               <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_2\">\n      <mets:mdWrap MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n
+        \         <premis:event xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>61bb7ae8-4d64-4253-9acd-b236e9f2d719</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>message
+        digest calculation</premis:eventType>\n            <premis:eventDateTime>2022-06-01T13:39:13.427517+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail>program=\"python\";
+        module=\"hashlib.sha256()\"</premis:eventDetail>\n            </premis:eventDetailInformation>\n
+        \           <premis:eventOutcomeInformation>\n              <premis:eventOutcome></premis:eventOutcome>\n
+        \             <premis:eventOutcomeDetail>\n                <premis:eventOutcomeDetailNote>6c6135a4dfdd19c5d9c55918b9501440bc0e250350c7de1a6e803b13469dbd64</premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_3\">\n      <mets:mdWrap MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n
+        \         <premis:event xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>578ce1a6-8ee7-47f4-8c09-356468baaaca</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>virus
+        check</premis:eventType>\n            <premis:eventDateTime>2022-06-01T13:39:14.775875+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail>program=\"ClamAV
+        (clamd)\"; version=\"ClamAV 0.99.2\"; virusDefinitions=\"24207/Tue Jan  9
+        21:18:11 2018\"</premis:eventDetail>\n            </premis:eventDetailInformation>\n
+        \           <premis:eventOutcomeInformation>\n              <premis:eventOutcome>Pass</premis:eventOutcome>\n
+        \             <premis:eventOutcomeDetail>\n                <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_4\">\n      <mets:mdWrap MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n
+        \         <premis:event xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>8905b808-c831-46cf-a6a7-6b97962b302b</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>format
+        identification</premis:eventType>\n            <premis:eventDateTime>2022-06-01T13:39:17.093042+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail>program=\"Siegfried\";
+        version=\"1.8.0\"</premis:eventDetail>\n            </premis:eventDetailInformation>\n
+        \           <premis:eventOutcomeInformation>\n              <premis:eventOutcome>Positive</premis:eventOutcome>\n
+        \             <premis:eventOutcomeDetail>\n                <premis:eventOutcomeDetailNote>fmt/569</premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_5\">\n      <mets:mdWrap MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n
+        \         <premis:event xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>e80df485-dc13-4665-8040-40959138833f</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>validation</premis:eventType>\n
+        \           <premis:eventDateTime>2022-06-01T13:39:20.378053+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail>program=\"MediaConch\";
+        version=\"18.03\"</premis:eventDetail>\n            </premis:eventDetailInformation>\n
+        \           <premis:eventOutcomeInformation>\n              <premis:eventOutcome>pass</premis:eventOutcome>\n
+        \             <premis:eventOutcomeDetail>\n                <premis:eventOutcomeDetailNote>MediaConch
+        implementation check result: The implementation check MediaConch EBML Implementation
+        Checker returned success for the following check(s): EBML-ELEMENTS-WITHIN-MAXSIZELENGTH,
+        EBML-ELEM-START, EBML-ELEMENT-NONMULTIPLES, EBML-HEADER-ELEMENTS-WITHIN-MAXSIZELENGTH,
+        EBML-VER-COH, EBML-ELEMENT-IN-SIZE-RANGE, EBML-VALID-MAXID, EBML-MINVER-COHERANT,
+        EBML-ELEMENT-VALID-RANGE, MKV-VALID-TRACKTYPE-VALUE, EBML-VALID-MAXSIZE, EBML-ELEMENTS-WITHIN-MAXIDLENGTH,
+        MKV-ELEMENT-VALID-PARENT, EBML-DOCVER-COH, EBML-HEADER-ELEMENTS-WITHIN-IDLENGTH-LIMIT,
+        MKV-SEEK-RESOLVE, EBML-ELEMENT-CONTAINS-MANDATES.</premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_6\">\n      <mets:mdWrap MDTYPE=\"PREMIS:AGENT\">\n        <mets:xmlData>\n
+        \         <premis:agent xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:agentIdentifier>\n
+        \             <premis:agentIdentifierType>preservation system</premis:agentIdentifierType>\n
+        \             <premis:agentIdentifierValue>Archivematica-1.14</premis:agentIdentifierValue>\n
+        \           </premis:agentIdentifier>\n            <premis:agentName>Archivematica</premis:agentName>\n
+        \           <premis:agentType>software</premis:agentType>\n          </premis:agent>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_7\">\n      <mets:mdWrap MDTYPE=\"PREMIS:AGENT\">\n        <mets:xmlData>\n
+        \         <premis:agent xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:agentIdentifier>\n
+        \             <premis:agentIdentifierType>repository code</premis:agentIdentifierType>\n
+        \             <premis:agentIdentifierValue>test</premis:agentIdentifierValue>\n
+        \           </premis:agentIdentifier>\n            <premis:agentName>test</premis:agentName>\n
+        \           <premis:agentType>organization</premis:agentType>\n          </premis:agent>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_8\">\n      <mets:mdWrap MDTYPE=\"PREMIS:AGENT\">\n        <mets:xmlData>\n
+        \         <premis:agent xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:agentIdentifier>\n
+        \             <premis:agentIdentifierType>Archivematica user pk</premis:agentIdentifierType>\n
+        \             <premis:agentIdentifierValue>1</premis:agentIdentifierValue>\n
+        \           </premis:agentIdentifier>\n            <premis:agentName>username=\"test\",
+        first_name=\"\", last_name=\"\"</premis:agentName>\n            <premis:agentType>Archivematica
+        user</premis:agentType>\n          </premis:agent>\n        </mets:xmlData>\n
+        \     </mets:mdWrap>\n    </mets:digiprovMD>\n  </mets:amdSec>\n  <mets:amdSec
+        ID=\"amdSec_2\">\n    <mets:techMD ID=\"techMD_2\">\n      <mets:mdWrap MDTYPE=\"PREMIS:OBJECT\">\n
+        \       <mets:xmlData>\n          <premis:object xmlns:premis=\"http://www.loc.gov/premis/v3\"
+        xsi:type=\"premis:file\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:objectIdentifier>\n
+        \             <premis:objectIdentifierType>UUID</premis:objectIdentifierType>\n
+        \             <premis:objectIdentifierValue>006c9a1d-eef5-4d17-8867-dc63e1ed3932</premis:objectIdentifierValue>\n
+        \           </premis:objectIdentifier>\n            <premis:objectCharacteristics>\n
+        \             <premis:compositionLevel>0</premis:compositionLevel>\n              <premis:fixity>\n
+        \               <premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>\n
+        \               <premis:messageDigest>0f4c134a051bd59d8e4b3de5fdba258309854dc3d4c5f2b88f35eee92a54f470</premis:messageDigest>\n
+        \             </premis:fixity>\n              <premis:size>28919</premis:size>\n
+        \             <premis:format>\n                <premis:formatDesignation>\n
+        \                 <premis:formatName>XML</premis:formatName>\n                  <premis:formatVersion>1.0</premis:formatVersion>\n
+        \               </premis:formatDesignation>\n                <premis:formatRegistry>\n
+        \                 <premis:formatRegistryName>PRONOM</premis:formatRegistryName>\n
+        \                 <premis:formatRegistryKey>fmt/101</premis:formatRegistryKey>\n
+        \               </premis:formatRegistry>\n              </premis:format>\n
+        \             <premis:creatingApplication>\n                <premis:dateCreatedByApplication>2022-06-01T13:39:27Z</premis:dateCreatedByApplication>\n
+        \             </premis:creatingApplication>\n              <premis:objectCharacteristicsExtension>\n
+        \               <fits xmlns=\"http://hul.harvard.edu/ois/xml/ns/fits/fits_output\"
+        xsi:schemaLocation=\"http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd\"
+        version=\"0.8.4\" timestamp=\"6/1/22 1:39 PM\">\n                  <identification>\n
+        \                   <identity format=\"Extensible Markup Language\" mimetype=\"text/xml\"
+        toolname=\"FITS\" toolversion=\"0.8.4\">\n                      <tool toolname=\"Exiftool\"
+        toolversion=\"9.13\"/>\n                      <tool toolname=\"NLNZ Metadata
+        Extractor\" toolversion=\"3.4GA\"/>\n                      <tool toolname=\"OIS
+        XML Metadata\" toolversion=\"0.2\"/>\n                      <tool toolname=\"ffident\"
+        toolversion=\"0.2\"/>\n                      <version toolname=\"NLNZ Metadata
+        Extractor\" toolversion=\"3.4GA\">1.0</version>\n                    </identity>\n
+        \                 </identification>\n                  <fileinfo>\n                    <lastmodified
+        toolname=\"Exiftool\" toolversion=\"9.13\" status=\"SINGLE_RESULT\">2022:06:01
+        13:39:21+00:00</lastmodified>\n                    <filepath toolname=\"OIS
+        File Information\" toolversion=\"0.2\" status=\"SINGLE_RESULT\">/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</filepath>\n
+        \                   <filename toolname=\"OIS File Information\" toolversion=\"0.2\"
+        status=\"SINGLE_RESULT\">METS.xml</filename>\n                    <size toolname=\"OIS
+        File Information\" toolversion=\"0.2\" status=\"SINGLE_RESULT\">28919</size>\n
+        \                   <fslastmodified toolname=\"OIS File Information\" toolversion=\"0.2\"
+        status=\"SINGLE_RESULT\">1654090761000</fslastmodified>\n                  </fileinfo>\n
+        \                 <filestatus/>\n                  <metadata>\n                    <text>\n
+        \                     <charset toolname=\"NLNZ Metadata Extractor\" toolversion=\"3.4GA\"
+        status=\"SINGLE_RESULT\">UTF-8</charset>\n                      <markupBasis
+        toolname=\"Exiftool\" toolversion=\"9.13\">XML</markupBasis>\n                      <markupBasisVersion
+        toolname=\"NLNZ Metadata Extractor\" toolversion=\"3.4GA\" status=\"SINGLE_RESULT\">1.0</markupBasisVersion>\n
+        \                     <markupLanguage toolname=\"OIS XML Metadata\" toolversion=\"0.2\"
+        status=\"SINGLE_RESULT\">http://www.loc.gov/standards/mets/version1121/mets.xsd</markupLanguage>\n
+        \                   </text>\n                  </metadata>\n                  <toolOutput>\n
+        \                   <tool name=\"file utility\" version=\"5.14\">\n                      <fileUtilityOutput
+        xmlns=\"\">\n                        <rawOutput>XML 1.0 document text\napplication/xml;
+        charset=us-ascii</rawOutput>\n                        <mimetype>application/xml</mimetype>\n
+        \                       <format>XML 1.0 document text</format>\n                      </fileUtilityOutput>\n
+        \                   </tool>\n                    <tool name=\"Exiftool\" version=\"9.13\">\n
+        \                     <exiftool xmlns=\"\">\n                        <rawOutput>ExifToolVersion\t9.13\nFileName\tMETS.xml\nDirectory\t/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f\nFileSize\t28
+        kB\nFileModifyDate\t2022:06:01 13:39:21+00:00\nFileAccessDate\t2022:06:01
+        13:39:27+00:00\nFileInodeChangeDate\t2022:06:01 13:39:27+00:00\nFilePermissions\trw-r--r--\nFileType\tXML\nMIMEType\tapplication/xml\nMetsSchemaLocation\thttp://www.loc.gov/METS/
+        http://www.loc.gov/standards/mets/version1121/mets.xsd\nMetsObjid\t095a23e0-64c0-4cc1-8f33-1a56fb9e510f\nMetsMetsHdrCreatedate\t2022:06:01
+        13:39:21\nMetsMetsHdrAgentRole\tCREATOR\nMetsMetsHdrAgentType\tOTHER\nMetsMetsHdrAgentOthertype\tSOFTWARE\nMetsMetsHdrAgentName\t6ba850ec-ec7f-4a53-9a8a-f3598aa39b93\nMetsMetsHdrAgentNote\tArchivematica
+        dashboard UUID\nMetsDmdSecId\tdmdSec_3\nMetsDmdSecCreated\t2022:06:01 13:39:21\nMetsDmdSecStatus\toriginal\nMetsDmdSecMdWrapMdtype\tPREMIS:OBJECT\nMetsDmdSecMdWrapXmlDataObjectSchemaLocation\thttp://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\nMetsDmdSecMdWrapXmlDataObjectVersion\t3.0\nMetsDmdSecMdWrapXmlDataObjectType\tpremis:intellectualEntity\nMetsDmdSecMdWrapXmlDataObjectObjectIdentifierObjectIdentifierType\tUUID\nMetsDmdSecMdWrapXmlDataObjectObjectIdentifierObjectIdentifierValue\tab234657-c34f-4d8a-b4e9-60ef5b7e8157\nMetsDmdSecMdWrapXmlDataObjectOriginalName\t%transferDirectory%logs/fileMeta/\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsCompositionLevel\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFixityMessageDigestAlgorithm\tSHA-256\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFixityMessageDigest\t6c6135a4dfdd19c5d9c55918b9501440bc0e250350c7de1a6e803b13469dbd64\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsSize\t1052413\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatDesignationFormatName\tMatroska\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatDesignationFormatVersion\t\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatRegistryFormatRegistryName\tPRONOM\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatRegistryFormatRegistryKey\tfmt/569\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsCreatingApplicationDateCreatedByApplication\t2021:05:18
+        15:17:13Z\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionVersion\t3.4.8-0ubuntu0.2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionCopyright\tCopyright
+        (c) 2007-2020 the FFmpeg developers\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionCompiler_ident\tgcc
+        7 (Ubuntu 7.5.0-3ubuntu1~18.04)\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionConfiguration\t--prefix=/usr
+        --extra-version=0ubuntu0.2 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu
+        --incdir=/usr/include/x86_64-linux-gnu --enable-gpl --disable-stripping --enable-avresample
+        --enable-avisynth --enable-gnutls --enable-ladspa --enable-libass --enable-libbluray
+        --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libflite --enable-libfontconfig
+        --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libmp3lame
+        --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus
+        --enable-libpulse --enable-librubberband --enable-librsvg --enable-libshine
+        --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora
+        --enable-libtwolame --enable-libvorbis --enable-libvpx --enable-libwavpack
+        --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq
+        --enable-libzvbi --enable-omx --enable-openal --enable-opengl --enable-sdl2
+        --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint
+        --enable-frei0r --enable-libopencv --enable-libx264 --enable-shared\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionName\tlibpostproc\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMajor\t54\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMinor\t7\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMicro\t100\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionVersion\t3540836\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionIdent\tpostproc54.7.100\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamWidth\t1280\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamHeight\t720\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCoded_width\t1280\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCoded_height\t720\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamHas_b_frames\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_aspect_ratio\t1:1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDisplay_aspect_ratio\t16:9\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamPix_fmt\tyuv420p\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamLevel\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChroma_location\tleft\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamRefs\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamQuarter_sample\tfalse\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDivx_packed\tfalse\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamIndex\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_name\taac\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_long_name\tAAC
+        (Advanced Audio Coding)\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamProfile\tLC\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_type\taudio\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_time_base\t2.08333333333333e-05\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_tag_string\t[0][0][0][0]\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_tag\t0x0000\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_fmt\tfltp\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_rate\t48000\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChannels\t6\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChannel_layout\t5.1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamBits_per_sample\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamR_frame_rate\tundef\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamAvg_frame_rate\tundef\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamTime_base\t0.001\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDuration_ts\t3600\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDuration\t3.600000\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamExtradata\t
+        00000000: 11b0                                     ..\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionDefault\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionDub\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionOriginal\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionComment\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionLyrics\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionKaraoke\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionForced\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionHearing_impaired\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionVisual_impaired\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionClean_effects\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionAttached_pic\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionTimed_thumbnails\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeChapters\t.\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFilename\t/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/objects/SampleVideo_1280x720_1mb.mkv\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatNb_streams\t2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatNb_programs\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFormat_name\tmatroska,webm\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFormat_long_name\tMatroska
+        / WebM\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatDuration\t3.600000\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatSize\t1052413\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatBit_rate\t2338695\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatProbe_score\t100\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatTagKey\tENCODER\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatTagValue\tLavf53.24.2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoXmlns\thttps://mediaarea.net/mediainfo\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoSchemaLocation\thttps://mediaarea.net/mediainfo
+        https://mediaarea.net/mediainfo/mediainfo_2_0.xsd\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoVersion\t2.0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibraryVersion\t18.05\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibraryUrl\thttps://mediaarea.net/MediaInfo\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibrary\tMediaInfoLib\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaRef\t/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/objects/SampleVideo_1280x720_1mb.mkv\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackVideoCount\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackAudioCount\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFileExtension\tmkv\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Version\t2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFileSize\t1052413\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackOverallBitRate\t2338696\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackIsStreamable\tYes\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFile_Modified_Date\tUTC
+        2021-05-18 15:17:13\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFile_Modified_Date_Local\t2021:05:18
+        15:17:13\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackEncoded_Application\tLavf53.24.2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Level\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_BVOP\tNo\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_QPel\tNo\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_GMC\t0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_Matrix\tDefault
+        (H.263)\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackWidth\t1280\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackHeight\t720\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSampled_Width\t1280\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSampled_Height\t720\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackPixelAspectRatio\t1.000\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDisplayAspectRatio\t1.778\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFrameRate_Mode\tVFR\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackColorSpace\tYUV\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChromaSubsampling\t4:2:0\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackBitDepth\t8\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackScanType\tProgressive\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackEncoded_Library\tLavc54.92.100\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackType\tAudio\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackStreamOrder\t1\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackId\t2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackUniqueID\t2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat\tAAC\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Profile\tLC\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackCodecID\tA_AAC-2\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDuration\t3.600\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannels\t6\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannelPositions\tFront:
+        L C R, Side: L R, LFE\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannelLayout\tC
+        L R Ls Rs LFE\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplesPerFrame\t1024\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplingRate\t48000\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplingCount\t172800\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFrameRate\t46.875\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackCompression_Mode\tLossy\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDelay\t0.005\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDelay_Source\tContainer\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDefault\tYes\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackForced\tNo\nMetsAmdSecDigiprovMDMdWrapXmlDataEventSchemaLocation\thttp://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\nMetsAmdSecDigiprovMDMdWrapXmlDataEventVersion\t3.0\nMetsAmdSecDigiprovMDMdWrapXmlDataEventEventIdentifierEventIdentifierType\tUUID\nMetsAmdSecDigiprovMDMdWrapXmlDataEventEventIdentifierEventIdentifierValue\te80df485-dc13-4665-8040-40959138833f\nMetsAmdSecDigiprovMDMdWrapXmlDataEventEventType\tvalidation\nMetsAmdSecDigiprovMDMdWrapXmlDataEventEventDateTime\t2022:06:01
+        13:39:20.378053+00:00\nMetsAmdSecDigiprovMDMdWrapXmlDataEventEventDetailInformationEventDetail\tprogram=\"MediaConch\";
+        version=\"18.03\"\nMetsAmdSecDigiprovMDMdWrapXmlDataEventEventOutcomeInformationEventOutcome\tpass\nMetsAmdSecDigiprovMDMdWrapXmlDataEventEventOutcomeInformationEventOutcomeDetailEventOutcomeDetailNote\tMediaConch
+        implementation check result: The implementation check MediaConch EBML Implementation
+        Checker returned success for the following check(s): EBML-ELEMENTS-WITHIN-MAXSIZELENGTH,
+        EBML-ELEM-START, EBML-ELEMENT-NONMULTIPLES, EBML-HEADER-ELEMENTS-WITHIN-MAXSIZELENGTH,
+        EBML-VER-COH, EBML-ELEMENT-IN-SIZE-RANGE, EBML-VALID-MAXID, EBML-MINVER-COHERANT,
+        EBML-ELEMENT-VALID-RANGE, MKV-VALID-TRACKTYPE-VALUE, EBML-VALID-MAXSIZE, EBML-ELEMENTS-WITHIN-MAXIDLENGTH,
+        MKV-ELEMENT-VALID-PARENT, EBML-DOCVER-COH, EBML-HEADER-ELEMENTS-WITHIN-IDLENGTH-LIMIT,
+        MKV-SEEK-RESOLVE, EBML-ELEMENT-CONTAINS-MANDATES.\nMetsAmdSecDigiprovMDMdWrapXmlDataEventLinkingAgentIdentifierLinkingAgentIdentifierType\tArchivematica
+        user pk\nMetsAmdSecDigiprovMDMdWrapXmlDataEventLinkingAgentIdentifierLinkingAgentIdentifierValue\t1\nMetsAmdSecDigiprovMDId\tdigiprovMD_8\nMetsAmdSecDigiprovMDCreated\t2022:06:01
+        13:39:21\nMetsAmdSecDigiprovMDMdWrapMdtype\tPREMIS:AGENT\nMetsAmdSecDigiprovMDMdWrapXmlDataAgentSchemaLocation\thttp://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\nMetsAmdSecDigiprovMDMdWrapXmlDataAgentVersion\t3.0\nMetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentIdentifierAgentIdentifierType\tArchivematica
+        user pk\nMetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentIdentifierAgentIdentifierValue\t1\nMetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentName\tusername=\"test\",
+        first_name=\"\", last_name=\"\"\nMetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentType\tArchivematica
+        user\nMetsAmdSecId\tamdSec_2\nMetsAmdSecTechMDId\ttechMD_2\nMetsAmdSecTechMDCreated\t2022:06:01
+        13:39:21\nMetsAmdSecTechMDStatus\tcurrent\nMetsAmdSecTechMDMdWrapMdtype\tPREMIS:OBJECT\nMetsAmdSecTechMDMdWrapXmlDataObjectSchemaLocation\thttp://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\nMetsAmdSecTechMDMdWrapXmlDataObjectVersion\t3.0\nMetsAmdSecTechMDMdWrapXmlDataObjectType\tpremis:intellectualEntity\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectIdentifierObjectIdentifierType\tUUID\nMetsAmdSecTechMDMdWrapXmlDataObjectObjectIdentifierObjectIdentifierValue\t175808d8-07be-43b1-af2f-df3b558abb67\nMetsAmdSecTechMDMdWrapXmlDataObjectOriginalName\t%transferDirectory%logs/\nMetsFileSecFileGrpUse\toriginal\nMetsFileSecFileGrpFileId\tfile-e7ecde2a-c936-4c80-acaf-73ee63d4a18b\nMetsFileSecFileGrpFileGroupid\tGroup-e7ecde2a-c936-4c80-acaf-73ee63d4a18b\nMetsFileSecFileGrpFileAdmid\tamdSec_1\nMetsFileSecFileGrpFileChecksum\t6c6135a4dfdd19c5d9c55918b9501440bc0e250350c7de1a6e803b13469dbd64\nMetsFileSecFileGrpFileChecksumtype\tSHA-256\nMetsFileSecFileGrpFileFLocatHref\tobjects/SampleVideo_1280x720_1mb.mkv\nMetsFileSecFileGrpFileFLocatLoctype\tOTHER\nMetsFileSecFileGrpFileFLocatOtherloctype\tSYSTEM\nMetsStructMapDivDivDivFptrFileid\tfile-e7ecde2a-c936-4c80-acaf-73ee63d4a18b\nMetsStructMapType\tlogical\nMetsStructMapId\tstructMap_2\nMetsStructMapLabel\tNormative
+        Directory Structure\nMetsStructMapDivType\tDirectory\nMetsStructMapDivLabel\tmkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f\nMetsStructMapDivDivAdmid\tamdSec_2\nMetsStructMapDivDivDmdid\tdmdSec_1\nMetsStructMapDivDivDivDmdid\tdmdSec_2\nMetsStructMapDivDivType\tDirectory\nMetsStructMapDivDivLabel\tobjects\nMetsStructMapDivDivDivType\tItem\nMetsStructMapDivDivDivLabel\tSampleVideo_1280x720_1mb.mkv</rawOutput>\n
+        \                       <ExifToolVersion>9.13</ExifToolVersion>\n                        <FileName>METS.xml</FileName>\n
+        \                       <Directory>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f</Directory>\n
+        \                       <FileSize>28 kB</FileSize>\n                        <FileModifyDate>2022:06:01
+        13:39:21+00:00</FileModifyDate>\n                        <FileAccessDate>2022:06:01
+        13:39:27+00:00</FileAccessDate>\n                        <FileInodeChangeDate>2022:06:01
+        13:39:27+00:00</FileInodeChangeDate>\n                        <FilePermissions>rw-r--r--</FilePermissions>\n
+        \                       <FileType>XML</FileType>\n                        <MIMEType>application/xml</MIMEType>\n
+        \                       <MetsSchemaLocation>http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version1121/mets.xsd</MetsSchemaLocation>\n
+        \                       <MetsObjid>095a23e0-64c0-4cc1-8f33-1a56fb9e510f</MetsObjid>\n
+        \                       <MetsMetsHdrCreatedate>2022:06:01 13:39:21</MetsMetsHdrCreatedate>\n
+        \                       <MetsMetsHdrAgentRole>CREATOR</MetsMetsHdrAgentRole>\n
+        \                       <MetsMetsHdrAgentType>OTHER</MetsMetsHdrAgentType>\n
+        \                       <MetsMetsHdrAgentOthertype>SOFTWARE</MetsMetsHdrAgentOthertype>\n
+        \                       <MetsMetsHdrAgentName>6ba850ec-ec7f-4a53-9a8a-f3598aa39b93</MetsMetsHdrAgentName>\n
+        \                       <MetsMetsHdrAgentNote>Archivematica dashboard UUID</MetsMetsHdrAgentNote>\n
+        \                       <MetsDmdSecId>dmdSec_3</MetsDmdSecId>\n                        <MetsDmdSecCreated>2022:06:01
+        13:39:21</MetsDmdSecCreated>\n                        <MetsDmdSecStatus>original</MetsDmdSecStatus>\n
+        \                       <MetsDmdSecMdWrapMdtype>PREMIS:OBJECT</MetsDmdSecMdWrapMdtype>\n
+        \                       <MetsDmdSecMdWrapXmlDataObjectSchemaLocation>http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd</MetsDmdSecMdWrapXmlDataObjectSchemaLocation>\n
+        \                       <MetsDmdSecMdWrapXmlDataObjectVersion>3.0</MetsDmdSecMdWrapXmlDataObjectVersion>\n
+        \                       <MetsDmdSecMdWrapXmlDataObjectType>premis:intellectualEntity</MetsDmdSecMdWrapXmlDataObjectType>\n
+        \                       <MetsDmdSecMdWrapXmlDataObjectObjectIdentifierObjectIdentifierType>UUID</MetsDmdSecMdWrapXmlDataObjectObjectIdentifierObjectIdentifierType>\n
+        \                       <MetsDmdSecMdWrapXmlDataObjectObjectIdentifierObjectIdentifierValue>ab234657-c34f-4d8a-b4e9-60ef5b7e8157</MetsDmdSecMdWrapXmlDataObjectObjectIdentifierObjectIdentifierValue>\n
+        \                       <MetsDmdSecMdWrapXmlDataObjectOriginalName>%transferDirectory%logs/fileMeta/</MetsDmdSecMdWrapXmlDataObjectOriginalName>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsCompositionLevel>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsCompositionLevel>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFixityMessageDigestAlgorithm>SHA-256</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFixityMessageDigestAlgorithm>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFixityMessageDigest>6c6135a4dfdd19c5d9c55918b9501440bc0e250350c7de1a6e803b13469dbd64</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFixityMessageDigest>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsSize>1052413</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsSize>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatDesignationFormatName>Matroska</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatDesignationFormatName>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatRegistryFormatRegistryName>PRONOM</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatRegistryFormatRegistryName>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatRegistryFormatRegistryKey>fmt/569</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsFormatFormatRegistryFormatRegistryKey>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsCreatingApplicationDateCreatedByApplication>2021:05:18
+        15:17:13Z</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsCreatingApplicationDateCreatedByApplication>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionVersion>3.4.8-0ubuntu0.2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionVersion>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionCopyright>Copyright
+        (c) 2007-2020 the FFmpeg developers</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionCopyright>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionCompiler_ident>gcc
+        7 (Ubuntu 7.5.0-3ubuntu1~18.04)</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionCompiler_ident>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionConfiguration>--prefix=/usr
+        --extra-version=0ubuntu0.2 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu
+        --incdir=/usr/include/x86_64-linux-gnu --enable-gpl --disable-stripping --enable-avresample
+        --enable-avisynth --enable-gnutls --enable-ladspa --enable-libass --enable-libbluray
+        --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libflite --enable-libfontconfig
+        --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libmp3lame
+        --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus
+        --enable-libpulse --enable-librubberband --enable-librsvg --enable-libshine
+        --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora
+        --enable-libtwolame --enable-libvorbis --enable-libvpx --enable-libwavpack
+        --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq
+        --enable-libzvbi --enable-omx --enable-openal --enable-opengl --enable-sdl2
+        --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint
+        --enable-frei0r --enable-libopencv --enable-libx264 --enable-shared</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeProgram_versionConfiguration>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionName>libpostproc</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionName>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMajor>54</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMajor>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMinor>7</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMinor>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMicro>100</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionMicro>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionVersion>3540836</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionVersion>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionIdent>postproc54.7.100</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeLibrary_versionsLibrary_versionIdent>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamWidth>1280</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamWidth>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamHeight>720</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamHeight>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCoded_width>1280</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCoded_width>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCoded_height>720</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCoded_height>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamHas_b_frames>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamHas_b_frames>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_aspect_ratio>1:1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_aspect_ratio>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDisplay_aspect_ratio>16:9</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDisplay_aspect_ratio>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamPix_fmt>yuv420p</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamPix_fmt>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamLevel>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamLevel>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChroma_location>left</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChroma_location>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamRefs>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamRefs>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamQuarter_sample>false</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamQuarter_sample>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDivx_packed>false</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDivx_packed>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamIndex>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamIndex>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_name>aac</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_name>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_long_name>AAC
+        (Advanced Audio Coding)</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_long_name>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamProfile>LC</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamProfile>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_type>audio</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_type>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_time_base>2.08333333333333e-05</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_time_base>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_tag_string>[0][0][0][0]</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_tag_string>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_tag>0x0000</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamCodec_tag>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_fmt>fltp</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_fmt>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_rate>48000</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamSample_rate>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChannels>6</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChannels>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChannel_layout>5.1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamChannel_layout>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamBits_per_sample>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamBits_per_sample>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamR_frame_rate>undef</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamR_frame_rate>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamAvg_frame_rate>undef</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamAvg_frame_rate>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamTime_base>0.001</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamTime_base>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDuration_ts>3600</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDuration_ts>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDuration>3.600000</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDuration>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamExtradata>00000000:
+        11b0                                     ..</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamExtradata>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionDefault>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionDefault>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionDub>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionDub>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionOriginal>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionOriginal>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionComment>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionComment>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionLyrics>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionLyrics>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionKaraoke>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionKaraoke>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionForced>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionForced>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionHearing_impaired>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionHearing_impaired>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionVisual_impaired>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionVisual_impaired>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionClean_effects>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionClean_effects>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionAttached_pic>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionAttached_pic>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionTimed_thumbnails>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeStreamsStreamDispositionTimed_thumbnails>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeChapters>.</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeChapters>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFilename>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/objects/SampleVideo_1280x720_1mb.mkv</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFilename>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatNb_streams>2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatNb_streams>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatNb_programs>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatNb_programs>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFormat_name>matroska,webm</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFormat_name>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFormat_long_name>Matroska
+        / WebM</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatFormat_long_name>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatDuration>3.600000</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatDuration>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatSize>1052413</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatSize>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatBit_rate>2338695</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatBit_rate>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatProbe_score>100</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatProbe_score>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatTagKey>ENCODER</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatTagKey>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatTagValue>Lavf53.24.2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionFfprobeFormatTagValue>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoXmlns>https://mediaarea.net/mediainfo</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoXmlns>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoSchemaLocation>https://mediaarea.net/mediainfo
+        https://mediaarea.net/mediainfo/mediainfo_2_0.xsd</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoSchemaLocation>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoVersion>2.0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoVersion>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibraryVersion>18.05</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibraryVersion>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibraryUrl>https://mediaarea.net/MediaInfo</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibraryUrl>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibrary>MediaInfoLib</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoCreatingLibrary>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaRef>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/extractPackagesChoice/mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/objects/SampleVideo_1280x720_1mb.mkv</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaRef>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackVideoCount>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackVideoCount>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackAudioCount>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackAudioCount>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFileExtension>mkv</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFileExtension>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Version>2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Version>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFileSize>1052413</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFileSize>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackOverallBitRate>2338696</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackOverallBitRate>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackIsStreamable>Yes</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackIsStreamable>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFile_Modified_Date>UTC
+        2021-05-18 15:17:13</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFile_Modified_Date>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFile_Modified_Date_Local>2021:05:18
+        15:17:13</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFile_Modified_Date_Local>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackEncoded_Application>Lavf53.24.2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackEncoded_Application>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Level>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Level>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_BVOP>No</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_BVOP>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_QPel>No</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_QPel>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_GMC>0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_GMC>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_Matrix>Default
+        (H.263)</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Settings_Matrix>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackWidth>1280</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackWidth>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackHeight>720</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackHeight>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSampled_Width>1280</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSampled_Width>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSampled_Height>720</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSampled_Height>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackPixelAspectRatio>1.000</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackPixelAspectRatio>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDisplayAspectRatio>1.778</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDisplayAspectRatio>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFrameRate_Mode>VFR</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFrameRate_Mode>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackColorSpace>YUV</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackColorSpace>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChromaSubsampling>4:2:0</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChromaSubsampling>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackBitDepth>8</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackBitDepth>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackScanType>Progressive</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackScanType>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackEncoded_Library>Lavc54.92.100</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackEncoded_Library>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackType>Audio</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackType>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackStreamOrder>1</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackStreamOrder>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackId>2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackId>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackUniqueID>2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackUniqueID>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat>AAC</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Profile>LC</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFormat_Profile>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackCodecID>A_AAC-2</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackCodecID>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDuration>3.600</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDuration>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannels>6</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannels>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannelPositions>Front:
+        L C R, Side: L R, LFE</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannelPositions>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannelLayout>C
+        L R Ls Rs LFE</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackChannelLayout>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplesPerFrame>1024</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplesPerFrame>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplingRate>48000</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplingRate>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplingCount>172800</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackSamplingCount>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFrameRate>46.875</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackFrameRate>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackCompression_Mode>Lossy</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackCompression_Mode>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDelay>0.005</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDelay>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDelay_Source>Container</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDelay_Source>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDefault>Yes</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackDefault>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackForced>No</MetsAmdSecTechMDMdWrapXmlDataObjectObjectCharacteristicsObjectCharacteristicsExtensionMediaInfoMediaTrackForced>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventSchemaLocation>http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd</MetsAmdSecDigiprovMDMdWrapXmlDataEventSchemaLocation>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventVersion>3.0</MetsAmdSecDigiprovMDMdWrapXmlDataEventVersion>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventEventIdentifierEventIdentifierType>UUID</MetsAmdSecDigiprovMDMdWrapXmlDataEventEventIdentifierEventIdentifierType>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventEventIdentifierEventIdentifierValue>e80df485-dc13-4665-8040-40959138833f</MetsAmdSecDigiprovMDMdWrapXmlDataEventEventIdentifierEventIdentifierValue>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventEventType>validation</MetsAmdSecDigiprovMDMdWrapXmlDataEventEventType>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventEventDateTime>2022:06:01
+        13:39:20.378053+00:00</MetsAmdSecDigiprovMDMdWrapXmlDataEventEventDateTime>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventEventDetailInformationEventDetail>program=\"MediaConch\";
+        version=\"18.03\"</MetsAmdSecDigiprovMDMdWrapXmlDataEventEventDetailInformationEventDetail>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventEventOutcomeInformationEventOutcome>pass</MetsAmdSecDigiprovMDMdWrapXmlDataEventEventOutcomeInformationEventOutcome>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventEventOutcomeInformationEventOutcomeDetailEventOutcomeDetailNote>MediaConch
+        implementation check result: The implementation check MediaConch EBML Implementation
+        Checker returned success for the following check(s): EBML-ELEMENTS-WITHIN-MAXSIZELENGTH,
+        EBML-ELEM-START, EBML-ELEMENT-NONMULTIPLES, EBML-HEADER-ELEMENTS-WITHIN-MAXSIZELENGTH,
+        EBML-VER-COH, EBML-ELEMENT-IN-SIZE-RANGE, EBML-VALID-MAXID, EBML-MINVER-COHERANT,
+        EBML-ELEMENT-VALID-RANGE, MKV-VALID-TRACKTYPE-VALUE, EBML-VALID-MAXSIZE, EBML-ELEMENTS-WITHIN-MAXIDLENGTH,
+        MKV-ELEMENT-VALID-PARENT, EBML-DOCVER-COH, EBML-HEADER-ELEMENTS-WITHIN-IDLENGTH-LIMIT,
+        MKV-SEEK-RESOLVE, EBML-ELEMENT-CONTAINS-MANDATES.</MetsAmdSecDigiprovMDMdWrapXmlDataEventEventOutcomeInformationEventOutcomeDetailEventOutcomeDetailNote>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventLinkingAgentIdentifierLinkingAgentIdentifierType>Archivematica
+        user pk</MetsAmdSecDigiprovMDMdWrapXmlDataEventLinkingAgentIdentifierLinkingAgentIdentifierType>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataEventLinkingAgentIdentifierLinkingAgentIdentifierValue>1</MetsAmdSecDigiprovMDMdWrapXmlDataEventLinkingAgentIdentifierLinkingAgentIdentifierValue>\n
+        \                       <MetsAmdSecDigiprovMDId>digiprovMD_8</MetsAmdSecDigiprovMDId>\n
+        \                       <MetsAmdSecDigiprovMDCreated>2022:06:01 13:39:21</MetsAmdSecDigiprovMDCreated>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapMdtype>PREMIS:AGENT</MetsAmdSecDigiprovMDMdWrapMdtype>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataAgentSchemaLocation>http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd</MetsAmdSecDigiprovMDMdWrapXmlDataAgentSchemaLocation>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataAgentVersion>3.0</MetsAmdSecDigiprovMDMdWrapXmlDataAgentVersion>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentIdentifierAgentIdentifierType>Archivematica
+        user pk</MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentIdentifierAgentIdentifierType>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentIdentifierAgentIdentifierValue>1</MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentIdentifierAgentIdentifierValue>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentName>username=\"test\",
+        first_name=\"\", last_name=\"\"</MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentName>\n
+        \                       <MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentType>Archivematica
+        user</MetsAmdSecDigiprovMDMdWrapXmlDataAgentAgentType>\n                        <MetsAmdSecId>amdSec_2</MetsAmdSecId>\n
+        \                       <MetsAmdSecTechMDId>techMD_2</MetsAmdSecTechMDId>\n
+        \                       <MetsAmdSecTechMDCreated>2022:06:01 13:39:21</MetsAmdSecTechMDCreated>\n
+        \                       <MetsAmdSecTechMDStatus>current</MetsAmdSecTechMDStatus>\n
+        \                       <MetsAmdSecTechMDMdWrapMdtype>PREMIS:OBJECT</MetsAmdSecTechMDMdWrapMdtype>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectSchemaLocation>http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd</MetsAmdSecTechMDMdWrapXmlDataObjectSchemaLocation>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectVersion>3.0</MetsAmdSecTechMDMdWrapXmlDataObjectVersion>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectType>premis:intellectualEntity</MetsAmdSecTechMDMdWrapXmlDataObjectType>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectIdentifierObjectIdentifierType>UUID</MetsAmdSecTechMDMdWrapXmlDataObjectObjectIdentifierObjectIdentifierType>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectObjectIdentifierObjectIdentifierValue>175808d8-07be-43b1-af2f-df3b558abb67</MetsAmdSecTechMDMdWrapXmlDataObjectObjectIdentifierObjectIdentifierValue>\n
+        \                       <MetsAmdSecTechMDMdWrapXmlDataObjectOriginalName>%transferDirectory%logs/</MetsAmdSecTechMDMdWrapXmlDataObjectOriginalName>\n
+        \                       <MetsFileSecFileGrpUse>original</MetsFileSecFileGrpUse>\n
+        \                       <MetsFileSecFileGrpFileId>file-e7ecde2a-c936-4c80-acaf-73ee63d4a18b</MetsFileSecFileGrpFileId>\n
+        \                       <MetsFileSecFileGrpFileGroupid>Group-e7ecde2a-c936-4c80-acaf-73ee63d4a18b</MetsFileSecFileGrpFileGroupid>\n
+        \                       <MetsFileSecFileGrpFileAdmid>amdSec_1</MetsFileSecFileGrpFileAdmid>\n
+        \                       <MetsFileSecFileGrpFileChecksum>6c6135a4dfdd19c5d9c55918b9501440bc0e250350c7de1a6e803b13469dbd64</MetsFileSecFileGrpFileChecksum>\n
+        \                       <MetsFileSecFileGrpFileChecksumtype>SHA-256</MetsFileSecFileGrpFileChecksumtype>\n
+        \                       <MetsFileSecFileGrpFileFLocatHref>objects/SampleVideo_1280x720_1mb.mkv</MetsFileSecFileGrpFileFLocatHref>\n
+        \                       <MetsFileSecFileGrpFileFLocatLoctype>OTHER</MetsFileSecFileGrpFileFLocatLoctype>\n
+        \                       <MetsFileSecFileGrpFileFLocatOtherloctype>SYSTEM</MetsFileSecFileGrpFileFLocatOtherloctype>\n
+        \                       <MetsStructMapDivDivDivFptrFileid>file-e7ecde2a-c936-4c80-acaf-73ee63d4a18b</MetsStructMapDivDivDivFptrFileid>\n
+        \                       <MetsStructMapType>logical</MetsStructMapType>\n                        <MetsStructMapId>structMap_2</MetsStructMapId>\n
+        \                       <MetsStructMapLabel>Normative Directory Structure</MetsStructMapLabel>\n
+        \                       <MetsStructMapDivType>Directory</MetsStructMapDivType>\n
+        \                       <MetsStructMapDivLabel>mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f</MetsStructMapDivLabel>\n
+        \                       <MetsStructMapDivDivAdmid>amdSec_2</MetsStructMapDivDivAdmid>\n
+        \                       <MetsStructMapDivDivDmdid>dmdSec_1</MetsStructMapDivDivDmdid>\n
+        \                       <MetsStructMapDivDivDivDmdid>dmdSec_2</MetsStructMapDivDivDivDmdid>\n
+        \                       <MetsStructMapDivDivType>Directory</MetsStructMapDivDivType>\n
+        \                       <MetsStructMapDivDivLabel>objects</MetsStructMapDivDivLabel>\n
+        \                       <MetsStructMapDivDivDivType>Item</MetsStructMapDivDivDivType>\n
+        \                       <MetsStructMapDivDivDivLabel>SampleVideo_1280x720_1mb.mkv</MetsStructMapDivDivDivLabel>\n
+        \                     </exiftool>\n                    </tool>\n                    <tool
+        name=\"NLNZ Metadata Extractor\" version=\"3.4GA\">\n                      <XML
+        xmlns=\"\">\n                        <METADATA>\n                          <FILENAME>METS.xml</FILENAME>\n
+        \                         <SEPARATOR>/</SEPARATOR>\n                          <PARENT>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f</PARENT>\n
+        \                         <CANONICALPATH>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</CANONICALPATH>\n
+        \                         <ABSOLUTEPATH>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</ABSOLUTEPATH>\n
+        \                         <PATH>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</PATH>\n
+        \                         <FILE>true</FILE>\n                          <DIRECTORY>false</DIRECTORY>\n
+        \                         <FILELENGTH>28919</FILELENGTH>\n                          <HIDDEN>false</HIDDEN>\n
+        \                         <ABSOLUTE>true</ABSOLUTE>\n                          <URL>file:/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</URL>\n
+        \                         <URI>file:/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</URI>\n
+        \                         <READ>true</READ>\n                          <WRITE>true</WRITE>\n
+        \                         <EXTENSION>xml</EXTENSION>\n                          <MODIFIED>2022-06-01
+        13:39:21</MODIFIED>\n                          <DATE>20220601</DATE>\n                          <DATEPATTERN>yyyyMMdd</DATEPATTERN>\n
+        \                         <TIME>133921000</TIME>\n                          <TIMEPATTERN>HHmmssSSS</TIMEPATTERN>\n
+        \                         <TYPE>application/xml</TYPE>\n                          <PID>null</PID>\n
+        \                         <OID>null</OID>\n                          <FID>null</FID>\n
+        \                         <PROCESSOR>unknown</PROCESSOR>\n                        </METADATA>\n
+        \                       <INFORMATION>\n                          <VERSION>1.0</VERSION>\n
+        \                         <ENCODING>UTF-8</ENCODING>\n                          <STANDALONE>unspecified</STANDALONE>\n
+        \                       </INFORMATION>\n                      </XML>\n                    </tool>\n
+        \                   <tool name=\"OIS File Information\" version=\"0.2\">\n
+        \                     <fits xsi:schemaLocation=\"http://hul.harvard.edu/ois/xml/ns/fits/fits_output
+        http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd\">\n                        <fileinfo>\n
+        \                         <filepath>/var/archivematica/sharedDirectory/watchedDirectories/workFlowDecisions/metadataReminder/mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3/objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</filepath>\n
+        \                         <filename>METS.xml</filename>\n                          <size>28919</size>\n
+        \                         <fslastmodified>1654090761000</fslastmodified>\n
+        \                       </fileinfo>\n                      </fits>\n                    </tool>\n
+        \                   <tool name=\"OIS XML Metadata\" version=\"0.2\">\n                      <fits
+        xsi:schemaLocation=\"http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd\">\n
+        \                       <identification>\n                          <identity
+        format=\"Extensible Markup Language\" mimetype=\"text/xml\"/>\n                        </identification>\n
+        \                       <metadata>\n                          <text>\n                            <markupLanguage>http://www.loc.gov/standards/mets/version1121/mets.xsd</markupLanguage>\n
+        \                         </text>\n                        </metadata>\n                      </fits>\n
+        \                   </tool>\n                    <tool name=\"ffident\" version=\"0.2\">\n
+        \                     <ffidentOutput xmlns=\"\">\n                        <shortName>XML</shortName>\n
+        \                       <longName>Extensible Markup Language</longName>\n
+        \                       <group>doc</group>\n                        <mimetypes>\n
+        \                         <mimetype>text/xml</mimetype>\n                        </mimetypes>\n
+        \                       <fileExtensions>\n                          <extension>xml</extension>\n
+        \                       </fileExtensions>\n                      </ffidentOutput>\n
+        \                   </tool>\n                    <tool name=\"Tika\" version=\"1.3\">\n
+        \                     <metadata xmlns=\"\">\n                        <field
+        name=\"Content-Type\">\n                          <value>application/xml</value>\n
+        \                       </field>\n                      </metadata>\n                    </tool>\n
+        \                 </toolOutput>\n                </fits>\n              </premis:objectCharacteristicsExtension>\n
+        \           </premis:objectCharacteristics>\n            <premis:originalName>%SIPDirectory%objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml</premis:originalName>\n
+        \         </premis:object>\n        </mets:xmlData>\n      </mets:mdWrap>\n
+        \   </mets:techMD>\n    <mets:digiprovMD ID=\"digiprovMD_9\">\n      <mets:mdWrap
+        MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n          <premis:event
+        xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>e90ef13c-ec4a-462d-9771-25798281e5b4</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>ingestion</premis:eventType>\n
+        \           <premis:eventDateTime>2022-06-01T13:39:27.359779+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail></premis:eventDetail>\n
+        \           </premis:eventDetailInformation>\n            <premis:eventOutcomeInformation>\n
+        \             <premis:eventOutcome></premis:eventOutcome>\n              <premis:eventOutcomeDetail>\n
+        \               <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_10\">\n      <mets:mdWrap MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n
+        \         <premis:event xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>401c1119-e6a2-423e-8e72-c20bf5669db5</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>message
+        digest calculation</premis:eventType>\n            <premis:eventDateTime>2022-06-01T13:39:27.403796+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail>program=\"python\";
+        module=\"hashlib.sha256()\"</premis:eventDetail>\n            </premis:eventDetailInformation>\n
+        \           <premis:eventOutcomeInformation>\n              <premis:eventOutcome></premis:eventOutcome>\n
+        \             <premis:eventOutcomeDetail>\n                <premis:eventOutcomeDetailNote>0f4c134a051bd59d8e4b3de5fdba258309854dc3d4c5f2b88f35eee92a54f470</premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_11\">\n      <mets:mdWrap MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n
+        \         <premis:event xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>5f802f9c-d482-4227-96b0-b6a786ef5c8a</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>virus
+        check</premis:eventType>\n            <premis:eventDateTime>2022-06-01T13:39:28.481981+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail>program=\"ClamAV
+        (clamd)\"; version=\"ClamAV 0.99.2\"; virusDefinitions=\"24207/Tue Jan  9
+        21:18:11 2018\"</premis:eventDetail>\n            </premis:eventDetailInformation>\n
+        \           <premis:eventOutcomeInformation>\n              <premis:eventOutcome>Pass</premis:eventOutcome>\n
+        \             <premis:eventOutcomeDetail>\n                <premis:eventOutcomeDetailNote></premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_12\">\n      <mets:mdWrap MDTYPE=\"PREMIS:EVENT\">\n        <mets:xmlData>\n
+        \         <premis:event xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:eventIdentifier>\n
+        \             <premis:eventIdentifierType>UUID</premis:eventIdentifierType>\n
+        \             <premis:eventIdentifierValue>6610a0d5-533a-49e2-bb4c-73ce412001a9</premis:eventIdentifierValue>\n
+        \           </premis:eventIdentifier>\n            <premis:eventType>format
+        identification</premis:eventType>\n            <premis:eventDateTime>2022-06-01T13:39:29.737651+00:00</premis:eventDateTime>\n
+        \           <premis:eventDetailInformation>\n              <premis:eventDetail>program=\"Siegfried\";
+        version=\"1.8.0\"</premis:eventDetail>\n            </premis:eventDetailInformation>\n
+        \           <premis:eventOutcomeInformation>\n              <premis:eventOutcome>Positive</premis:eventOutcome>\n
+        \             <premis:eventOutcomeDetail>\n                <premis:eventOutcomeDetailNote>fmt/101</premis:eventOutcomeDetailNote>\n
+        \             </premis:eventOutcomeDetail>\n            </premis:eventOutcomeInformation>\n
+        \           <premis:linkingAgentIdentifier>\n              <premis:linkingAgentIdentifierType>preservation
+        system</premis:linkingAgentIdentifierType>\n              <premis:linkingAgentIdentifierValue>Archivematica-1.14</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>repository code</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>test</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n            <premis:linkingAgentIdentifier>\n
+        \             <premis:linkingAgentIdentifierType>Archivematica user pk</premis:linkingAgentIdentifierType>\n
+        \             <premis:linkingAgentIdentifierValue>1</premis:linkingAgentIdentifierValue>\n
+        \           </premis:linkingAgentIdentifier>\n          </premis:event>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_13\">\n      <mets:mdWrap MDTYPE=\"PREMIS:AGENT\">\n        <mets:xmlData>\n
+        \         <premis:agent xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:agentIdentifier>\n
+        \             <premis:agentIdentifierType>preservation system</premis:agentIdentifierType>\n
+        \             <premis:agentIdentifierValue>Archivematica-1.14</premis:agentIdentifierValue>\n
+        \           </premis:agentIdentifier>\n            <premis:agentName>Archivematica</premis:agentName>\n
+        \           <premis:agentType>software</premis:agentType>\n          </premis:agent>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_14\">\n      <mets:mdWrap MDTYPE=\"PREMIS:AGENT\">\n        <mets:xmlData>\n
+        \         <premis:agent xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:agentIdentifier>\n
+        \             <premis:agentIdentifierType>repository code</premis:agentIdentifierType>\n
+        \             <premis:agentIdentifierValue>test</premis:agentIdentifierValue>\n
+        \           </premis:agentIdentifier>\n            <premis:agentName>test</premis:agentName>\n
+        \           <premis:agentType>organization</premis:agentType>\n          </premis:agent>\n
+        \       </mets:xmlData>\n      </mets:mdWrap>\n    </mets:digiprovMD>\n    <mets:digiprovMD
+        ID=\"digiprovMD_15\">\n      <mets:mdWrap MDTYPE=\"PREMIS:AGENT\">\n        <mets:xmlData>\n
+        \         <premis:agent xmlns:premis=\"http://www.loc.gov/premis/v3\" xsi:schemaLocation=\"http://www.loc.gov/premis/v3
+        http://www.loc.gov/standards/premis/v3/premis.xsd\" version=\"3.0\">\n            <premis:agentIdentifier>\n
+        \             <premis:agentIdentifierType>Archivematica user pk</premis:agentIdentifierType>\n
+        \             <premis:agentIdentifierValue>1</premis:agentIdentifierValue>\n
+        \           </premis:agentIdentifier>\n            <premis:agentName>username=\"test\",
+        first_name=\"\", last_name=\"\"</premis:agentName>\n            <premis:agentType>Archivematica
+        user</premis:agentType>\n          </premis:agent>\n        </mets:xmlData>\n
+        \     </mets:mdWrap>\n    </mets:digiprovMD>\n  </mets:amdSec>\n  <mets:fileSec>\n
+        \   <mets:fileGrp USE=\"original\">\n      <mets:file ID=\"file-e7ecde2a-c936-4c80-acaf-73ee63d4a18b\"
+        GROUPID=\"Group-e7ecde2a-c936-4c80-acaf-73ee63d4a18b\" ADMID=\"amdSec_1\">\n
+        \       <mets:FLocat xlink:href=\"objects/SampleVideo_1280x720_1mb.mkv\" LOCTYPE=\"OTHER\"
+        OTHERLOCTYPE=\"SYSTEM\"/>\n      </mets:file>\n    </mets:fileGrp>\n    <mets:fileGrp
+        USE=\"submissionDocumentation\">\n      <mets:file ID=\"file-006c9a1d-eef5-4d17-8867-dc63e1ed3932\"
+        GROUPID=\"Group-006c9a1d-eef5-4d17-8867-dc63e1ed3932\" ADMID=\"amdSec_2\">\n
+        \       <mets:FLocat xlink:href=\"objects/submissionDocumentation/transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f/METS.xml\"
+        LOCTYPE=\"OTHER\" OTHERLOCTYPE=\"SYSTEM\"/>\n      </mets:file>\n    </mets:fileGrp>\n
+        \ </mets:fileSec>\n  <mets:structMap TYPE=\"physical\" ID=\"structMap_1\"
+        LABEL=\"Archivematica default\">\n    <mets:div TYPE=\"Directory\" LABEL=\"mkv-characterization-64f4cb73-60bc-49f2-ab75-d83c9365b7d3\"
+        DMDID=\"dmdSec_1\">\n      <mets:div TYPE=\"Directory\" LABEL=\"objects\">\n
+        \       <mets:div TYPE=\"Item\" LABEL=\"SampleVideo_1280x720_1mb.mkv\">\n
+        \         <mets:fptr FILEID=\"file-e7ecde2a-c936-4c80-acaf-73ee63d4a18b\"/>\n
+        \       </mets:div>\n        <mets:div TYPE=\"Directory\" LABEL=\"submissionDocumentation\">\n
+        \         <mets:div TYPE=\"Directory\" LABEL=\"transfer-mkv-characterization-095a23e0-64c0-4cc1-8f33-1a56fb9e510f\">\n
+        \           <mets:div TYPE=\"Item\" LABEL=\"METS.xml\">\n              <mets:fptr
+        FILEID=\"file-006c9a1d-eef5-4d17-8867-dc63e1ed3932\"/>\n            </mets:div>\n
+        \         </mets:div>\n        </mets:div>\n      </mets:div>\n    </mets:div>\n
+        \ </mets:structMap>\n</mets:mets>\n"
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename="METS.64f4cb73-60bc-49f2-ab75-d83c9365b7d3.xml"
+      Content-Language:
+      - en
+      Content-Length:
+      - '119107'
+      Content-Type:
+      - application/xml
+      Date:
+      - Wed, 01 Jun 2022 19:47:25 GMT
+      Server:
+      - nginx/1.20.2
+      Vary:
+      - Accept, Accept-Language, Cookie
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This commit adds an `AMClient.extract_aip_mets_file()` method, which simplifies retrieval of Archivematica METS files by handling the complexity of determining the appropriate relative filepath "behind the scenes".