### PR TITLE
Encode file contents UTF-8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 21.10b0
+  rev: 22.3.0
   hooks:
   - id: black
     args: [--safe, --quiet]

--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -17,6 +17,7 @@ import logging
 import os
 import pprint
 import re
+from six import ensure_binary
 import sys
 
 import requests
@@ -686,7 +687,7 @@ class AMClient(object):
         headers.update({"Content-Type": "text/csv; charset=utf-8"})
         return utils._call_url_json(
             url,
-            params=data.encode("utf-8"),
+            params=ensure_binary(data, encoding="utf-8"),
             method=utils.METHOD_POST,
             headers=headers,
             enhanced_errors=getattr(self, "enhanced_errors", False),

--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -686,7 +686,7 @@ class AMClient(object):
         headers.update({"Content-Type": "text/csv; charset=utf-8"})
         return utils._call_url_json(
             url,
-            params=data,
+            params=data.encode("utf-8"),
             method=utils.METHOD_POST,
             headers=headers,
             enhanced_errors=getattr(self, "enhanced_errors", False),

--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -685,9 +685,10 @@ class AMClient(object):
         data = file_obj.read()
         headers = self._am_auth_headers()
         headers.update({"Content-Type": "text/csv; charset=utf-8"})
+        encoded_data = ensure_binary(data, encoding="utf-8")
         return utils._call_url_json(
             url,
-            params=ensure_binary(data, encoding="utf-8"),
+            params=encoded_data,
             method=utils.METHOD_POST,
             headers=headers,
             enhanced_errors=getattr(self, "enhanced_errors", False),

--- a/amclient/utils.py
+++ b/amclient/utils.py
@@ -125,7 +125,7 @@ def _call_url_json(
             data = _call_url(
                 url,
                 method=method,
-                data=params.encode("utf-8"),
+                data=params,
                 headers=headers,
                 assume_json=assume_json,
             )

--- a/amclient/utils.py
+++ b/amclient/utils.py
@@ -125,7 +125,7 @@ def _call_url_json(
             data = _call_url(
                 url,
                 method=method,
-                data=params,
+                data=params.encode("utf-8"),
                 headers=headers,
                 assume_json=assume_json,
             )

--- a/amclient/version.py
+++ b/amclient/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 
 def version():

--- a/tests/test_amclient.py
+++ b/tests/test_amclient.py
@@ -1316,7 +1316,7 @@ class TestAMClient(unittest.TestCase):
             assert client.validate_csv(validator, file_obj) == {"valid": "true"}
             mock_request.assert_called_once_with(
                 "POST",
-                data=file_contents,
+                data=file_contents.encode("utf-8"),
                 params=None,
                 headers=expected_headers,
                 url="{}/api/v2beta/validate/{}/".format(client.am_url, validator),
@@ -1337,7 +1337,7 @@ class TestAMClient(unittest.TestCase):
             assert result.message == error_message
             mock_request.assert_called_once_with(
                 "POST",
-                data=file_contents,
+                data=file_contents.encode("utf-8"),
                 params=None,
                 headers=expected_headers,
                 url="{}/api/v2beta/validate/{}/".format(client.am_url, validator),


### PR DESCRIPTION
Encodes file contents to be validated as UTF-8 before delivering.

fixes archivematica/Issues#1569