### PR TITLE
Support detailed tasks in the get_jobs method

### DIFF
--- a/amclient/amclient.py
+++ b/amclient/amclient.py
@@ -626,6 +626,8 @@ class AMClient:
             value = getattr(self, f"job_{attribute}", None)
             if value is not None:
                 params[attribute] = value
+        if hasattr(self, "detailed"):
+            params["detailed"] = self.detailed
         return utils._call_url_json(
             url, headers=self._am_auth_headers(), params=params, method=utils.METHOD_GET
         )


### PR DESCRIPTION
This adds support for the detailed parameter introduced in the Jobs API endpoint in Archivematica 1.16.0.

Connected to https://github.com/archivematica/Issues/issues/1641